### PR TITLE
Fix BorderControl disappearing around the game window.

### DIFF
--- a/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
@@ -44,7 +44,7 @@ namespace ClassicUO.Dust765.UI.Gumps
             });
             startY += 22;
 
-            Add(new Label($"Version: {CUOEnviroment.Version}", false, HUE_TEXT, WIDTH - 30, 1, FontStyle.None)
+            Add(new Label($"Version: {CUOEnviroment.Version}", true, HUE_TITLE, WIDTH - 30, 1, FontStyle.None)
             {
                 X = 20,
                 Y = startY

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -156,8 +156,15 @@ namespace ClassicUO.Game.Scenes
             Client.Game.Window.AllowUserResizing = true;
 
             Camera.Zoom = ProfileManager.CurrentProfile.DefaultScale;
-            Camera.Bounds.X = Math.Max(0, ProfileManager.CurrentProfile.GameWindowPosition.X);
-            Camera.Bounds.Y = Math.Max(0, ProfileManager.CurrentProfile.GameWindowPosition.Y);
+            // When not in fullsize mode the WorldViewportGump starts at (Camera.X - BORDER_WIDTH,
+            // Camera.Y - BORDER_WIDTH).  Ensure Camera is at least BORDER_WIDTH so the UO border
+            // is always on-screen.  Fullsize mode explicitly positions the viewport at -BORDER_WIDTH
+            // via SetGameWindowPosition, so that path stays unrestricted.
+            int minCamPos = ProfileManager.CurrentProfile.GameWindowFullSize
+                ? 0
+                : Game.UI.Gumps.WorldViewportGump.BORDER_WIDTH;
+            Camera.Bounds.X = Math.Max(minCamPos, ProfileManager.CurrentProfile.GameWindowPosition.X);
+            Camera.Bounds.Y = Math.Max(minCamPos, ProfileManager.CurrentProfile.GameWindowPosition.Y);
             Camera.Bounds.Width = Math.Max(0, ProfileManager.CurrentProfile.GameWindowSize.X);
             Camera.Bounds.Height = Math.Max(0, ProfileManager.CurrentProfile.GameWindowSize.Y);
 

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -35,7 +35,6 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
-using ClassicUO.Dust765.UI.Gumps;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Game.UI.Gumps.CharCreation;
 using ClassicUO.Game.UI.Gumps.Login;
@@ -529,9 +528,6 @@ namespace ClassicUO.Game.Scenes
                 LastCharacterManager.Save(Account, World.ServerName, Characters[index]);
 
                 CurrentLoginStep = LoginSteps.EnteringBritania;
-
-                // Mostra loading screen enquanto o mundo carrega
-                WorldLoadingScreenGump.Show();
 
                 NetClient.Socket.Send_SelectCharacter(index, Characters[index], NetClient.Socket.LocalIP);
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -207,9 +207,14 @@ namespace ClassicUO.Game.UI.Gumps
                 position.X = Client.Game.Window.ClientBounds.Width - (Width - BORDER_WIDTH);
             }
 
-            if (position.X < -BORDER_WIDTH)
+            // In fullsize mode the viewport sits at -BORDER_WIDTH so the UO border is intentionally
+            // off-screen (game content fills the full window).  In normal mode we clamp to 0 so the
+            // UO border is always visible on-screen.
+            int minPos = ProfileManager.CurrentProfile.GameWindowFullSize ? -BORDER_WIDTH : 0;
+
+            if (position.X < minPos)
             {
-                position.X = -BORDER_WIDTH;
+                position.X = minPos;
             }
 
             if (position.Y + Height - BORDER_WIDTH > Client.Game.Window.ClientBounds.Height)
@@ -217,9 +222,9 @@ namespace ClassicUO.Game.UI.Gumps
                 position.Y = Client.Game.Window.ClientBounds.Height - (Height - BORDER_WIDTH);
             }
 
-            if (position.Y < -BORDER_WIDTH)
+            if (position.Y < minPos)
             {
-                position.Y = -BORDER_WIDTH;
+                position.Y = minPos;
             }
 
             Location = position;


### PR DESCRIPTION
Prevent viewport from moving to -BORDER_WIDTH when GameWindowFullSize is disabled,
and clamp Camera.Bounds on GameScene initialization to ensure the border
starts visible when loading profiles saved in fullsize mode.