### PR TITLE
 v3.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.userosscache
 *.sln.docstates
 estudo/
+_tazuo_legacy_tmp
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -7,8 +7,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>ClassicUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>3.0.7</AssemblyVersion>
-    <FileVersion>3.0.7</FileVersion>
+    <AssemblyVersion>3.0.8</AssemblyVersion>
+    <FileVersion>3.0.8</FileVersion>
     <Copyright>Dust765</Copyright>
     <StartupObject></StartupObject>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -685,7 +685,8 @@ namespace ClassicUO.Configuration
         public string UseLandTexturesWhereAvailable { get; set; } = "Use land textures where available(Experimental)";
         public string SOSGumpID { get; set; } = "SOS Gump ID";
         public string NearbyItemGump { get; set; } = "Enable nearby item gump";
-        public string ShowUseLootModalOnCtrl { get; set; } = "Show Use/Loot modal when pressing Ctrl (nearby items)";
+        public string ShowUseLootModalOnCtrl { get; set; } = "Show nearby Use/Loot modal (assign hotkey below)";
+        public string NearbyItemModalHotkeyHint { get; set; } = "Hotkey (mouse over world, click field, press key, OK):";
         #endregion
 
         #region Tooltips

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -809,7 +809,6 @@ namespace ClassicUO.Configuration
         public string OffscreenTargeting { get; set; } = "Offscreen targeting (always on)";
         public string SetTargetOutRange { get; set; } = "Set target with is out range";
         public string OverrideContainerOpenRange { get; set; } = "Override container open range";
-        public string ShowCloseFriendInWordMapGump { get; set; } = "Show Close Friend in WordMapGump";
         public string AutoAvoidObstaculesAndMobiles { get; set; } = "Auto avoid obstacules and mobiles";
         public string RazorTargetToLasttargetString { get; set; } = "Razor * Target * to lasttarget string";
         public string TextForTargetMsgHead { get; set; } = "Text for Target Msg Head: ";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -443,6 +443,9 @@ namespace ClassicUO.Configuration
         public ushort HighlightLastTargetTypeStunnedHue { get; set; } = 0x0044;
         public int HighlightLastTargetTypeMortalled { get; set; } = 0; // 0 = off, 1 = white, 2 = pink, 3 = ice, 4 = fire, 5 = special, 6 = custom
         public ushort HighlightLastTargetTypeMortalledHue { get; set; } = 0x0044;
+        public bool MoongateRecolorEnabled { get; set; }
+        public int MoongateHueStyle { get; set; } = 1;
+        public ushort MoongateCustomHue { get; set; } = 0x0044;
         // ## BEGIN - END ## // VISUAL HELPERS
         // ## BEGIN - END ## // HEALTHBAR
         public bool HighlightHealthBarByState { get; set; } //## Highlights mobiles healthbars if they're poisoned or para
@@ -936,6 +939,12 @@ namespace ClassicUO.Configuration
         [JsonConverter(typeof(Point2Converter))]
         public Point InfoBarSize { get; set; } = new Point(400, 20);
         public bool InfoBarLocked { get; set; } = false;
+
+        [JsonConverter(typeof(Point2Converter))]
+        public Point NearbyItemsGumpSize { get; set; } = new Point(640, 440);
+
+        [JsonConverter(typeof(Point2Converter))]
+        public Point NearbyItemsGumpPosition { get; set; } = new Point(-50000, -50000);
         [JsonConverter(typeof(Json.UOFontIndexConverter))]
         public byte InfoBarFont { get; set; } = 1;
         public int InfoBarFontSize { get; set; } = 18;
@@ -1006,7 +1015,8 @@ namespace ClassicUO.Configuration
 
         public bool EnableAutoLootProgressBar { get; set; } = true;
         public bool EnableNearbyItemGump { get; set; } = false;
-
+        public int NearbyItemGumpHotkeyKey { get; set; }
+        public uint NearbyItemGumpHotkeyMod { get; set; }
 
         public void Save(string path, bool saveGumps = true)
         {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -281,8 +281,6 @@ namespace ClassicUO.Configuration
         public bool NameOverheadToggled { get; set; } = false;
         public bool ShowTargetRangeIndicator { get; set; }
         public bool PartyInviteGump { get; set; }
-        // ## BEGIN - END ## // NAMEOVERHEAD
-        public bool ShowHPLineInNOH { get; set; } = false;
         public bool NameOverheadPinnedToggled { get; set; } = false;
         public bool NameOverheadBackgroundToggled { get; set; } = false;
         // ## BEGIN - END ## // NAMEOVERHEAD
@@ -743,6 +741,7 @@ namespace ClassicUO.Configuration
         public bool WorldMapTopMost { get; set; }
         public bool WorldMapFreeView { get; set; }
         public bool WorldMapShowParty { get; set; } = true;
+        public bool WorldMapShowGuild { get; set; }
         public int WorldMapZoomIndex { get; set; } = 4;
         public bool WorldMapShowCoordinates { get; set; } = true;
         public bool WorldMapShowMouseCoordinates { get; set; } = true;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -413,6 +413,7 @@ namespace ClassicUO.Configuration
         public int TreeType { get; set; } = 0; // 0 = off, 1 = stump, 2 = tile
         public bool ColorTreeTile { get; set; }
         public ushort TreeTileHue { get; set; } = 0x0044;
+        public bool EnlargeJewelryOnPaperdoll { get; set; }
         // ## BEGIN - END ## // ART / HUE CHANGES
         // ## BEGIN - END ## // VISUAL HELPERS
         public bool HighlightTileAtRange { get; set; }
@@ -525,7 +526,6 @@ namespace ClassicUO.Configuration
         public bool ShowDeathOnWorldmap { get; set; } = false;
         public bool ForceGargoyleWalk { get; set; } = true;
 
-        public bool ShowMapCloseFriend { get; set; } = true;
         public bool AutoAvoidMobiles { get; set; } = false;
         // ## BEGIN - END ## // MISC2
         // ## BEGIN - END ## // MACROS
@@ -741,7 +741,7 @@ namespace ClassicUO.Configuration
         public bool WorldMapTopMost { get; set; }
         public bool WorldMapFreeView { get; set; }
         public bool WorldMapShowParty { get; set; } = true;
-        public bool WorldMapShowGuild { get; set; }
+        public bool WorldMapShowGuild { get; set; } = true;
         public int WorldMapZoomIndex { get; set; } = 4;
         public bool WorldMapShowCoordinates { get; set; } = true;
         public bool WorldMapShowMouseCoordinates { get; set; } = true;

--- a/src/ClassicUO.Client/Dust765/Dust765/CombatCollection.cs
+++ b/src/ClassicUO.Client/Dust765/Dust765/CombatCollection.cs
@@ -58,6 +58,7 @@ namespace ClassicUO.Dust765.Dust765
         public const ushort BRIGHT_FIRE_COLOR = 0x0496;
         public const ushort BRIGHT_POISON_COLOR = 0x0A0B;
         public const ushort BRIGHT_PARALYZE_COLOR = 0x0A13;
+        public const ushort MOONGATE_GRAPHIC = 0x0F6C;
         // ## BEGIN - END ## // ART / HUE CHANGES
         // ## BEGIN - END ## // MACROS
         //USED VARS
@@ -321,6 +322,37 @@ namespace ClassicUO.Dust765.Dust765
 
             return hue;
         }
+        public static ushort MoongateHue(ushort graphic, ushort currentHue)
+        {
+            if (graphic != MOONGATE_GRAPHIC)
+            {
+                return currentHue;
+            }
+
+            Profile p = ProfileManager.CurrentProfile;
+
+            if (p == null || !p.MoongateRecolorEnabled)
+            {
+                return currentHue;
+            }
+
+            switch (p.MoongateHueStyle)
+            {
+                case 1:
+                    return BRIGHT_WHITE_COLOR;
+                case 2:
+                    return BRIGHT_PINK_COLOR;
+                case 3:
+                    return BRIGHT_ICE_COLOR;
+                case 4:
+                    return BRIGHT_FIRE_COLOR;
+                case 5:
+                    return p.MoongateCustomHue;
+                default:
+                    return currentHue;
+            }
+        }
+
         public static ushort WeaponsHue(ushort hue)
         {
             if (ProfileManager.CurrentProfile.GlowingWeaponsType == 1)

--- a/src/ClassicUO.Client/Dust765/External/OnCastingGump.cs
+++ b/src/ClassicUO.Client/Dust765/External/OnCastingGump.cs
@@ -94,6 +94,12 @@ namespace ClassicUO.Dust765.External
             GameCursor._spellTime = 0;
             // ## BEGIN - END ## // VISUAL HELPERS
         }
+
+        public override void Dispose()
+        {
+            Stop();
+            base.Dispose();
+        }
         /*
         public void OnMessage(string text, uint hue, string name, bool isunicode = true)
         {

--- a/src/ClassicUO.Client/Dust765/SplashScreen/SplashForm.cs
+++ b/src/ClassicUO.Client/Dust765/SplashScreen/SplashForm.cs
@@ -105,8 +105,8 @@ namespace ClassicUO.Dust765
             var sf = new StringFormat { Alignment = StringAlignment.Center, LineAlignment = StringAlignment.Center };
 
             // ── Logo centralizado no topo ────────────────────────────────────
-            const int logoH = 90;
-            int logoY = 14;
+            const int logoH = 148;
+            int logoY = 10;
             if (_logo != null)
             {
                 double scale = Math.Min((double)(w - pad * 2) / _logo.Width, (double)logoH / _logo.Height);

--- a/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
@@ -77,7 +77,7 @@ namespace ClassicUO.Dust765.UI.Gumps
                 "- Fix Target hue by notoriety",
                 "- Fix Show nearly item gump",
                 "- Fix OnCasting after recall",
-                "- Show Guild in Wolrd Map",
+                "- Show Guild in World Map",
             };
 
             foreach (string line in sections)

--- a/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
@@ -67,14 +67,17 @@ namespace ClassicUO.Dust765.UI.Gumps
             int contentY = 0;
             string[] sections =
             {
-                "/c[yellow]v3.0.7/cd",
+                "/c[yellow]v3.0.8/cd",
                 "",
                 "/c[yellow]Features/cd",
-                "- Add splash loading with loading mul files (instead of loading from uo files)",
-
+                "- Add Search in Options",
+                "",
                 "/c[yellow]Fixes/cd",
-                "- Fix BorderControl disappearing around the game window",
-                "- Fixed start from uostealth",
+                "- Fix nameplateoverheadgump",
+                "- Fix Target hue by notoriety",
+                "- Fix Show nearly item gump",
+                "- Fix OnCasting after recall",
+                "- Show Guild in Wolrd Map",
             };
 
             foreach (string line in sections)

--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -578,6 +578,11 @@ namespace ClassicUO.Game
 
         public static void Attack(uint serial)
         {
+            if (!World.InGame || World.Player == null || World.Player.IsDestroyed)
+            {
+                return;
+            }
+
             if (ProfileManager.CurrentProfile.EnabledCriminalActionQuery)
             {
                 Mobile m = World.Mobiles.Get(serial);

--- a/src/ClassicUO.Client/Game/GameCursor.cs
+++ b/src/ClassicUO.Client/Game/GameCursor.cs
@@ -217,6 +217,65 @@ namespace ClassicUO.Game
 
         public ItemHold ItemHold { get; } = new ItemHold();
 
+        private bool TryJewelryEnlargedDrag(out int dw, out int dh, out Rectangle srcUvRect)
+        {
+            dw = dh = 0;
+            srcUvRect = default;
+
+            if (!ItemHold.Enabled
+                || ItemHold.IsGumpTexture
+                || ProfileManager.CurrentProfile?.EnlargeJewelryOnPaperdoll != true)
+            {
+                return false;
+            }
+
+            byte layer = ItemHold.ItemData.Layer;
+
+            if (layer != (byte)Layer.Ring && layer != (byte)Layer.Bracelet)
+            {
+                return false;
+            }
+
+            ushort g = GetDraggingItemGraphic();
+
+            if (g == 0xFFFF)
+            {
+                return false;
+            }
+
+            Rectangle bounds = Client.Game.Arts.GetRealArtBounds(g);
+            int bw = Math.Max(1, bounds.Width);
+            int bh = Math.Max(1, bounds.Height);
+            bool isBracelet = layer == (byte)Layer.Bracelet;
+            float mult = isBracelet ? 1.55f : 1.8f;
+            int cap = isBracelet ? 20 : 22;
+            int minSz = isBracelet ? 8 : 10;
+            double logicalW = Math.Min(cap, Math.Max(minSz, bw * mult));
+            double logicalH = Math.Min(cap, Math.Max(minSz, bh * mult));
+            float scaleMul = 1f;
+            Profile p = ProfileManager.CurrentProfile;
+
+            if (p != null
+                && p.ScaleItemsInsideContainers
+                && SerialHelper.IsValid(ItemHold.Container)
+                && !SerialHelper.IsMobile(ItemHold.Container))
+            {
+                scaleMul = UIManager.ContainerScale;
+            }
+
+            dw = (int)Math.Ceiling(logicalW * scaleMul);
+            dh = (int)Math.Ceiling(logicalH * scaleMul);
+            ref readonly var artInfo = ref Client.Game.Arts.GetArt(g);
+
+            if (artInfo.Texture == null)
+            {
+                return false;
+            }
+
+            srcUvRect = new Rectangle(artInfo.UV.X + bounds.X, artInfo.UV.Y + bounds.Y, bw, bh);
+            return true;
+        }
+
         private ushort GetDraggingItemGraphic()
         {
             if (ItemHold.Enabled)
@@ -234,6 +293,11 @@ namespace ClassicUO.Game
 
         private Point GetDraggingItemOffset()
         {
+            if (TryJewelryEnlargedDrag(out int jw, out int jh, out _))
+            {
+                return new Point((jw >> 1) - ItemHold.MouseOffset.X, (jh >> 1) - ItemHold.MouseOffset.Y);
+            }
+
             ushort graphic = GetDraggingItemGraphic();
 
             if (graphic != 0xFFFF)
@@ -328,11 +392,28 @@ namespace ClassicUO.Game
                     int x = ItemHold.FixedX - offset.X;
                     int y = ItemHold.FixedY - offset.Y;
 
+                    int hitW = artInfo.UV.Width;
+                    int hitH = artInfo.UV.Height;
+
+                    if (TryJewelryEnlargedDrag(out int jw, out int jh, out _))
+                    {
+                        hitW = jw;
+                        hitH = jh;
+                    }
+                    else if (
+                        ProfileManager.CurrentProfile != null
+                        && ProfileManager.CurrentProfile.ScaleItemsInsideContainers
+                    )
+                    {
+                        hitW = (int)(hitW * UIManager.ContainerScale);
+                        hitH = (int)(hitH * UIManager.ContainerScale);
+                    }
+
                     if (
                         Mouse.Position.X >= x
-                        && Mouse.Position.X < x + artInfo.UV.Width
+                        && Mouse.Position.X < x + hitW
                         && Mouse.Position.Y >= y
-                        && Mouse.Position.Y < y + artInfo.UV.Height
+                        && Mouse.Position.Y < y + hitH
                     )
                     {
                         if (!ItemHold.IgnoreFixedPosition)
@@ -590,14 +671,24 @@ namespace ClassicUO.Game
                         ItemHold.HasAlpha ? .5f : 1f
                     );
 
-                    var rect = new Rectangle(
-                        x,
-                        y,
-                        (int)(artInfo.UV.Width * scale),
-                        (int)(artInfo.UV.Height * scale)
-                    );
+                    Rectangle rect;
 
-                    sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                    if (TryJewelryEnlargedDrag(out int jw, out int jh, out Rectangle srcJewel))
+                    {
+                        rect = new Rectangle(x, y, jw, jh);
+                        sb.Draw(artInfo.Texture, rect, srcJewel, hue);
+                    }
+                    else
+                    {
+                        rect = new Rectangle(
+                            x,
+                            y,
+                            (int)(artInfo.UV.Width * scale),
+                            (int)(artInfo.UV.Height * scale)
+                        );
+
+                        sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                    }
 
                     if (
                         ItemHold.Amount > 1
@@ -608,7 +699,14 @@ namespace ClassicUO.Game
                         rect.X += 5;
                         rect.Y += 5;
 
-                        sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                        if (TryJewelryEnlargedDrag(out _, out _, out Rectangle srcJ2))
+                        {
+                            sb.Draw(artInfo.Texture, rect, srcJ2, hue);
+                        }
+                        else
+                        {
+                            sb.Draw(artInfo.Texture, rect, artInfo.UV, hue);
+                        }
                     }
                 }
             }

--- a/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
@@ -181,7 +181,9 @@ namespace ClassicUO.Game.GameObjects
                 return;
             }
 
-            int offY = -NameOverheadGump.CurrentHeight;
+            int offY = Parent is Entity ent
+                ? -NameOverheadGump.GetFloatingTextVerticalReserve(ent.Serial)
+                : 0;
 
             Point p = new Point();
 

--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -171,7 +171,7 @@ namespace ClassicUO.Game.GameObjects
             UpdateTextCoordsV();
         }
 
-        public void SetInWorldTile(ushort x, ushort y, sbyte z)
+        public virtual void SetInWorldTile(ushort x, ushort y, sbyte z)
         {
             X = x;
             Y = y;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -955,7 +955,7 @@ namespace ClassicUO.Game.GameObjects
                 return;
             }
 
-            int offY = NameOverheadGump.CurrentHeight;
+            int offY = NameOverheadGump.GetFloatingTextVerticalReserve(Serial);
 
             bool health = ProfileManager.CurrentProfile.ShowMobilesHP;
             int alwaysHP = ProfileManager.CurrentProfile.MobileHPShowWhen;

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -101,6 +101,17 @@ namespace ClassicUO.Game.GameObjects
         public override bool InWarMode { get; set; }
         public IReadOnlyDictionary<BuffIconType, BuffIcon> BuffIcons => _buffIcons;
 
+        public override void SetInWorldTile(ushort x, ushort y, sbyte z)
+        {
+            bool positionChanged = x != X || y != Y || z != Z;
+            base.SetInWorldTile(x, y, z);
+            if (positionChanged)
+            {
+                ClearSteps();
+                Walker.Reset();
+            }
+        }
+
         public ref Ability PrimaryAbility => ref Abilities[0];
         public ref Ability SecondaryAbility => ref Abilities[1];
         protected override bool IsWalking => LastStepTime > Time.Ticks - Constants.PLAYER_WALKING_DELAY;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -247,6 +247,11 @@ namespace ClassicUO.Game.GameObjects
                 }
             }
 
+            if (OnGround && Graphic == CombatCollection.MOONGATE_GRAPHIC)
+            {
+                hue = CombatCollection.MoongateHue(Graphic, hue);
+            }
+
             hueVec = ShaderHueTranslator.GetHueVector(hue, partial, alpha);
 
             if (!IsMulti && !IsCoin && Amount > 1 && ItemData.IsStackable)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -244,10 +244,18 @@ namespace ClassicUO.Game.GameObjects
                 overridedHue = CombatCollection.LastFriendHue(this, overridedHue);
                 hueVec.Y = 1;
             }
-            if (ProfileManager.CurrentProfile.HighlightLastTargetType != 0 && (isLastTarget || isAttack))
+            if (isLastTarget || isAttack)
             {
-                overridedHue = CombatCollection.LastTargetHue(this, overridedHue);
-                hueVec.Y = 1;
+                if (ProfileManager.CurrentProfile.HighlightLastTargetType != 0)
+                {
+                    overridedHue = CombatCollection.LastTargetHue(this, overridedHue);
+                    hueVec.Y = 1;
+                }
+                else
+                {
+                    overridedHue = Notoriety.GetHue(NotorietyFlag);
+                    hueVec.Y = 1;
+                }
             }
             if (ProfileManager.CurrentProfile.PreviewFields)
             {

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -99,6 +99,8 @@ namespace ClassicUO.Game.GameObjects
             if (ProfileManager.CurrentProfile.DisplayRadius && Distance == ProfileManager.CurrentProfile.DisplayRadiusDistance && System.Math.Abs(Z - World.Player.Z) < 11)
                 hue = ProfileManager.CurrentProfile.DisplayRadiusHue;
 
+            hue = CombatCollection.MoongateHue(Graphic, hue);
+
             Vector3 hueVec = ShaderHueTranslator.GetHueVector(hue, partial, AlphaHue / 255f);
 
             // ## BEGIN - END ## // VISUAL HELPERS

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -132,6 +132,9 @@ namespace ClassicUO.Game.Managers
             if (mobile == null)
                 return false;
 
+            if (mobile.Serial == TargetManager.LastTargetInfo.Serial)
+                return true;
+
             if (mobile.Equals(World.Player) && ActiveOverheadOptions.HasFlag(NameOverheadOptions.ExcludeSelf)
                 && !ActiveOverheadOptions.HasFlag(NameOverheadOptions.Self))
                 return false;

--- a/src/ClassicUO.Client/Game/Managers/TargetManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TargetManager.cs
@@ -161,6 +161,11 @@ namespace ClassicUO.Game.Managers
             get { return _lastAttack; }
             set
             {
+                if (_lastAttack == value)
+                {
+                    return;
+                }
+
                 _lastAttack = value;
 
                 Profile profile = ProfileManager.CurrentProfile;

--- a/src/ClassicUO.Client/Game/Managers/WorldMapEntityManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/WorldMapEntityManager.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -100,8 +100,8 @@ namespace ClassicUO.Game.Managers
             {
                 return ((World.ClientFeatures.Flags & CharacterListFlags.CLF_NEW_MOVEMENT_SYSTEM) == 0 || _ackReceived) &&
                         EncryptionHelper.Type == 0 &&
-                        ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.WorldMapShowParty && 
-                        UIManager.GetGump<WorldMapGump>() != null; // horrible, but works
+                        ProfileManager.CurrentProfile != null && (ProfileManager.CurrentProfile.WorldMapShowParty || ProfileManager.CurrentProfile.WorldMapShowGuild) &&
+                        UIManager.GetGump<WorldMapGump>() != null;
             }
         }
 

--- a/src/ClassicUO.Client/Game/Managers/WorldTextManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/WorldTextManager.cs
@@ -129,7 +129,7 @@ namespace ClassicUO.Game.Managers
                 Entity entity = World.Get(TargetManager.LastAttack);
                 if (entity != null && !entity.IsDestroyed)
                 {
-                    int offY = -NameOverheadGump.CurrentHeight;
+                    int offY = -NameOverheadGump.GetFloatingTextVerticalReserve(entity.Serial);
                     Point p = new Point(entity.RealScreenPosition.X, entity.RealScreenPosition.Y);
                     if (entity is Mobile m)
                     {

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1324,6 +1324,88 @@ namespace ClassicUO.Game.Scenes
             return ok;
         }
 
+        private static bool NearbyItemIsModifierKeycode(int pk)
+        {
+            switch ((SDL.SDL_Keycode)pk)
+            {
+                case SDL.SDL_Keycode.SDLK_LCTRL:
+                case SDL.SDL_Keycode.SDLK_RCTRL:
+                case SDL.SDL_Keycode.SDLK_LSHIFT:
+                case SDL.SDL_Keycode.SDLK_RSHIFT:
+                case SDL.SDL_Keycode.SDLK_LALT:
+                case SDL.SDL_Keycode.SDLK_RALT:
+                case SDL.SDL_Keycode.SDLK_LGUI:
+                case SDL.SDL_Keycode.SDLK_RGUI:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool NearbyItemKeyEquals(SDL.SDL_Keycode ev, int pk)
+        {
+            if ((int)ev == pk)
+            {
+                return true;
+            }
+
+            int evi = (int)ev;
+
+            if (pk == (int)SDL.SDL_Keycode.SDLK_LCTRL || pk == (int)SDL.SDL_Keycode.SDLK_RCTRL)
+            {
+                return evi == (int)SDL.SDL_Keycode.SDLK_LCTRL || evi == (int)SDL.SDL_Keycode.SDLK_RCTRL;
+            }
+
+            if (pk == (int)SDL.SDL_Keycode.SDLK_LSHIFT || pk == (int)SDL.SDL_Keycode.SDLK_RSHIFT)
+            {
+                return evi == (int)SDL.SDL_Keycode.SDLK_LSHIFT || evi == (int)SDL.SDL_Keycode.SDLK_RSHIFT;
+            }
+
+            if (pk == (int)SDL.SDL_Keycode.SDLK_LALT || pk == (int)SDL.SDL_Keycode.SDLK_RALT)
+            {
+                return evi == (int)SDL.SDL_Keycode.SDLK_LALT || evi == (int)SDL.SDL_Keycode.SDLK_RALT;
+            }
+
+            if (pk == (int)SDL.SDL_Keycode.SDLK_LGUI || pk == (int)SDL.SDL_Keycode.SDLK_RGUI)
+            {
+                return evi == (int)SDL.SDL_Keycode.SDLK_LGUI || evi == (int)SDL.SDL_Keycode.SDLK_RGUI;
+            }
+
+            return false;
+        }
+
+        private static bool NearbyItemHotkeyMatches(SDL.SDL_KeyboardEvent e, int storedKey, uint storedMod)
+        {
+            int pk = storedKey == 0 ? (int)SDL.SDL_Keycode.SDLK_LCTRL : storedKey;
+            var evKey = (SDL.SDL_Keycode)e.key;
+
+            if (!NearbyItemKeyEquals(evKey, pk))
+            {
+                return false;
+            }
+
+            if (NearbyItemIsModifierKeycode(pk))
+            {
+                return true;
+            }
+
+            uint em = (uint)e.mod & ~(uint)Keyboard.IgnoreKeyMod;
+            uint sm = storedMod & ~(uint)Keyboard.IgnoreKeyMod;
+            uint guiMask = (uint)SDL.SDL_Keymod.SDL_KMOD_LGUI | (uint)SDL.SDL_Keymod.SDL_KMOD_RGUI;
+
+            bool eshift = (em & (uint)SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0;
+            bool ectrl = (em & (uint)SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0;
+            bool ealt = (em & (uint)SDL.SDL_Keymod.SDL_KMOD_ALT) != 0;
+            bool egui = (em & guiMask) != 0;
+
+            bool sshift = (sm & (uint)SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0;
+            bool sctrl = (sm & (uint)SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0;
+            bool salt = (sm & (uint)SDL.SDL_Keymod.SDL_KMOD_ALT) != 0;
+            bool sgui = (sm & guiMask) != 0;
+
+            return eshift == sshift && ectrl == sctrl && ealt == salt && egui == sgui;
+        }
+
         internal override void OnKeyDown(SDL.SDL_KeyboardEvent e)
         {
             if ((SDL.SDL_Keycode)e.key == SDL.SDL_Keycode.SDLK_TAB && (bool)e.repeat)
@@ -1336,9 +1418,16 @@ namespace ClassicUO.Game.Scenes
                 TargetManager.CancelTarget();
             }
 
-            if((SDL.SDL_Keycode)e.key == SDL.SDL_Keycode.SDLK_LCTRL && UIManager.IsMouseOverWorld && !Client.Game.GameCursor.ItemHold.Enabled && ProfileManager.CurrentProfile.EnableNearbyItemGump && NearbyItems.NearbyItemGump == null )
+            if (ProfileManager.CurrentProfile.EnableNearbyItemGump
+                && NearbyItems.NearbyItemGump == null
+                && UIManager.IsMouseOverWorld
+                && !Client.Game.GameCursor.ItemHold.Enabled
+                && NearbyItemHotkeyMatches(
+                    e,
+                    ProfileManager.CurrentProfile.NearbyItemGumpHotkeyKey,
+                    ProfileManager.CurrentProfile.NearbyItemGumpHotkeyMod))
             {
-                UIManager.Add(new NearbyItems());
+                NearbyItems.TryOpen();
             }
 
             if ((SDL.SDL_Keycode)e.key == SDL.SDL_Keycode.SDLK_F9 && ProfileManager.CurrentProfile?.PvP_QuickTargetEnemyList == true)

--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -122,6 +122,23 @@ namespace ClassicUO.Game.UI.Controls
 
         public event EventHandler<int> OnOptionSelected;
 
+        internal bool MatchesSearch(string term)
+        {
+            if (string.IsNullOrEmpty(term) || _items == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < _items.Length; i++)
+            {
+                if (_items[i] != null && _items[i].IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return _label?.Text != null && _label.Text.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {

--- a/src/ClassicUO.Client/Game/UI/Controls/GothicStyleButton.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GothicStyleButton.cs
@@ -217,9 +217,11 @@ namespace ClassicUO.Game.UI.Controls
         {
             if (button == ClassicUO.Input.MouseButtonType.Left)
             {
+                bool wasPressed = _isPressed;
+                bool releasedOnButton = x >= 0 && y >= 0 && x < Width && y < Height;
                 _isPressed = false;
 
-                if (MouseIsOver)
+                if (wasPressed && releasedOnButton)
                 {
                     OnClick?.Invoke();
                 }

--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -58,11 +58,13 @@ namespace ClassicUO.Game.UI.Controls
 
             CanMove = true;
 
-            AddLabel("Set hotkey:", 0, 0);
+            const int hotkeyRowY = 20;
+            AddLabel("Set hotkey:", 0, 2);
 
             _hotkeyBox = new HotkeyBox
             {
-                X = 80
+                X = 80,
+                Y = hotkeyRowY
             };
 
             _hotkeyBox.HotkeyChanged += BoxOnHotkeyChanged;
@@ -70,11 +72,12 @@ namespace ClassicUO.Game.UI.Controls
 
             Add(_hotkeyBox);
 
+            int buttonsY = hotkeyRowY + _hotkeyBox.Height + 8;
             Add
             (
                 new NiceButton
                 (
-                    0, _hotkeyBox.Height + 3, 100, 25,
+                    0, buttonsY, 100, 25,
                     ButtonAction.Activate, "Uncheck all", 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.UncheckAll, IsSelectable = false }
             );
@@ -83,12 +86,13 @@ namespace ClassicUO.Game.UI.Controls
             (
                 new NiceButton
                 (
-                    120, _hotkeyBox.Height + 3, 100, 25,
+                    120, buttonsY, 100, 25,
                     ButtonAction.Activate, "Check all", 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.CheckAll, IsSelectable = false }
             );
 
-            Add(checkBoxScroll = new ScrollArea(0, 60, 300, 400, true));
+            int scrollTop = buttonsY + 25 + 10;
+            Add(checkBoxScroll = new ScrollArea(0, scrollTop, 300, 368, true));
 
             SetupOptionCheckboxes();
 

--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -35,6 +35,7 @@ using System.Collections.Generic;
 using ClassicUO.Assets;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Game.UI.Gumps.Login;
 using ClassicUO.Resources;
 using SDL3;
 
@@ -58,8 +59,8 @@ namespace ClassicUO.Game.UI.Controls
 
             CanMove = true;
 
-            const int hotkeyRowY = 20;
-            AddLabel("Set hotkey:", 0, 2);
+            const int hotkeyRowY = 34;
+            AddLabel("Set hotkey:", 0, 8);
 
             _hotkeyBox = new HotkeyBox
             {
@@ -92,7 +93,13 @@ namespace ClassicUO.Game.UI.Controls
             );
 
             int scrollTop = buttonsY + 25 + 10;
-            Add(checkBoxScroll = new ScrollArea(0, scrollTop, 300, 368, true));
+            int ow = LoginLayoutHelper.OptionsWidth;
+            int oh = LoginLayoutHelper.OptionsHeight;
+            int scrollW = Math.Max(280, ow - 342);
+            int scrollH = Math.Max(200, oh - scrollTop - 58);
+            Add(checkBoxScroll = new ScrollArea(0, scrollTop, scrollW, scrollH, true));
+            checkBoxScroll.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
+            checkBoxScroll.UpdateScrollbarPosition();
 
             SetupOptionCheckboxes();
 

--- a/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -84,6 +84,8 @@ namespace ClassicUO.Game.UI.Controls
         internal Label TextLabel { get; }
 
         public int ButtonParameter { get; set; }
+
+        public bool IsSwitchPage => _action == ButtonAction.SwitchPage;
 
         public bool IsSelectable { get; set; } = true;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/AutoLootOptions.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AutoLootOptions.cs
@@ -11,6 +11,7 @@ namespace ClassicUO.Game.UI.Gumps
 {
     internal class AutoLootOptions : Gump
     {
+        private const ushort _autoLootTextHue = 0x080A;
         public AutoLootOptions() : base(0, 0)
         {
             if (!AutoLootManager.Instance.IsLoaded)
@@ -34,27 +35,27 @@ namespace ClassicUO.Game.UI.Gumps
         {
             Add(new AlphaBlendControl(0.85f) { Width = Width, Height = Height });
 
-            SettingsSection topSecion = new SettingsSection("Simple Auto Loot", Width);
+            SettingsSection topSecion = new SettingsSection("Simple Auto Loot", Width, _autoLootTextHue);
 
-            topSecion.Add(new UOLabel("Enable auto loot", 1, 0, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
+            topSecion.Add(new UOLabel("Enable auto loot", 1, _autoLootTextHue, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
 
             Checkbox enable;
             topSecion.AddRight(enable = new Checkbox(0x00D2, 0x00D3, "", 0xff, 0xffff) { IsChecked = ProfileManager.CurrentProfile.EnableAutoLoot });
             enable.ValueChanged += (e, v) => { ProfileManager.CurrentProfile.EnableAutoLoot = enable.IsChecked; };
 
-            topSecion.Add(new UOLabel("Show progress bar while looting", 1, 0, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
+            topSecion.Add(new UOLabel("Show progress bar while looting", 1, _autoLootTextHue, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
 
             Checkbox enablepb;
             topSecion.AddRight(enablepb = new Checkbox(0x00D2, 0x00D3, "", 0xff, 0xffff) { IsChecked = ProfileManager.CurrentProfile.EnableAutoLootProgressBar });
             enablepb.ValueChanged += (e, v) => { ProfileManager.CurrentProfile.EnableAutoLootProgressBar = enablepb.IsChecked; };
 
-            topSecion.Add(new UOLabel("Hue corpse after processing", 1, 0, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
+            topSecion.Add(new UOLabel("Hue corpse after processing", 1, _autoLootTextHue, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_LEFT, 0, ClassicUO.Game.FontStyle.None));
             Checkbox hueCorpse;
             topSecion.AddRight(hueCorpse = new Checkbox(0x00D2, 0x00D3, "", 0xff, 0xffff) { IsChecked = ProfileManager.CurrentProfile.HueCorpseAfterAutoloot });
             hueCorpse.ValueChanged += (e, v) => { ProfileManager.CurrentProfile.HueCorpseAfterAutoloot = hueCorpse.IsChecked; };
 
             NiceButton addEntry;
-            topSecion.Add(addEntry = new NiceButton(0, 0, 100, 25, ButtonAction.Activate, "Add entry") { IsSelectable = false });
+            topSecion.Add(addEntry = new NiceButton(0, 0, 100, 25, ButtonAction.Activate, "Add entry", 0, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_CENTER, _autoLootTextHue) { IsSelectable = false });
             addEntry.MouseUp += (e, v) =>
             {
                 AutoLootManager.Instance.AddLootItem();
@@ -64,7 +65,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(topSecion);
 
             ScrollArea entries = new ScrollArea(0, topSecion.Y + topSecion.Height + 25, Width - 2, Height - topSecion.Y - topSecion.Height - 25, true);
-            SettingsSection entriesSection = new SettingsSection("Loot entries", Width - 2);
+            SettingsSection entriesSection = new SettingsSection("Loot entries", Width - 2, _autoLootTextHue);
             entries.Add(entriesSection);
 
             BuildEntries(entriesSection);
@@ -88,7 +89,7 @@ namespace ClassicUO.Game.UI.Gumps
                     x += 55;
                 }
 
-                InputField graphicInput = new InputField(0x0BB8, 0xFF, 0xFFF, true, 100, 50) { X = x };
+                InputField graphicInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 100, 50) { X = x };
                 graphicInput.SetText(autoLootItem.Graphic.ToString());
                 graphicInput.TextChanged += (s, e) =>
                 {
@@ -104,7 +105,7 @@ namespace ClassicUO.Game.UI.Gumps
                 area.Add(graphicInput);
                 x += graphicInput.Width + 5;
 
-                InputField hueInput = new InputField(0x0BB8, 0xFF, 0xFFF, true, 100, 50) { X = x };
+                InputField hueInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 100, 50) { X = x };
                 hueInput.SetText(autoLootItem.Hue == ushort.MaxValue ? "-1" : autoLootItem.Hue.ToString());
                 hueInput.TextChanged += (s, e) =>
                 {
@@ -121,7 +122,7 @@ namespace ClassicUO.Game.UI.Gumps
                 x += hueInput.Width + 5;
 
                 NiceButton delete;
-                area.Add(delete = new NiceButton(x, 0, 90, 49, ButtonAction.Activate, "Delete") { IsSelectable = false, DisplayBorder = true });
+                area.Add(delete = new NiceButton(x, 0, 90, 49, ButtonAction.Activate, "Delete", 0, ClassicUO.Assets.TEXT_ALIGN_TYPE.TS_CENTER, _autoLootTextHue) { IsSelectable = false, DisplayBorder = true });
                 delete.MouseUp += (s, e) =>
                 {
                     if (e.Button == Input.MouseButtonType.Left)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1253,6 +1253,24 @@ namespace ClassicUO.Game.UI.Gumps
                         point.Y = (hit.Height >> 1) - (originalSize.Y >> 1);
                     }
 
+                    if (ProfileManager.CurrentProfile.EnlargeJewelryOnPaperdoll
+                        && _item != null
+                        && (_item.ItemData.Layer == (byte)Layer.Ring || _item.ItemData.Layer == (byte)Layer.Bracelet)
+                        && rect.Width > 0
+                        && rect.Height > 0)
+                    {
+                        bool isBracelet = _item.ItemData.Layer == (byte)Layer.Bracelet;
+                        float jMult = isBracelet ? 1.55f : 1.8f;
+                        int jMin = isBracelet ? 8 : 9;
+                        int pad = 2;
+                        int jw = Math.Min(hit.Width - pad, Math.Max(jMin, (int)Math.Ceiling(rect.Width * jMult)));
+                        int jh = Math.Min(hit.Height - pad, Math.Max(jMin, (int)Math.Ceiling(rect.Height * jMult)));
+                        originalSize.X = jw;
+                        originalSize.Y = jh;
+                        point.X = (hit.Width >> 1) - (jw >> 1);
+                        point.Y = (hit.Height >> 1) - (jh >> 1);
+                    }
+
                     batcher.Draw
                     (
                         texture,

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoadingGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoadingGump.cs
@@ -108,8 +108,8 @@ namespace ClassicUO.Game.UI.Gumps.Login
             });
 
             // Logo maior
-            const int LogoMaxWidth  = 280;
-            const int LogoMaxHeight = 68;
+            const int LogoMaxWidth  = 420;
+            const int LogoMaxHeight = 108;
             string logoPath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Client", "logodust.png");
             _logoTexture = PNGLoader.Instance.GetImageTexture(logoPath);
             if (_logoTexture != null)
@@ -118,23 +118,22 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 int logoW = (int)(_logoTexture.Width * scale);
                 int logoH = (int)(_logoTexture.Height * scale);
                 int logoX = panelX + ((ModalWidth - logoW) >> 1);
-                int logoY = panelY + 16;
+                int logoY = panelY + 12;
                 Add(new CustomGumpPic(logoX, logoY, _logoTexture, logoW, logoH, 0));
             }
 
-            // Linha de acento superior (3px, brilhante)
+            int accentY = panelY + 128;
             Add(new RoundedColorBox(ModalWidth, 3, AccentColor, 0)
             {
                 X = panelX,
-                Y = panelY + 92
+                Y = accentY
             });
 
-            // Label de status com texto branco legível
             string initialLabel = _baseLabelText + ".";
             _label = new UOLabel(initialLabel, 1, 0xFFFF, TEXT_ALIGN_TYPE.TS_CENTER, LabelMaxWidth, FontStyle.BlackBorder)
             {
                 X = panelX + ((ModalWidth - LabelMaxWidth) >> 1),
-                Y = panelY + 110
+                Y = accentY + 14
             };
             Add(_label);
             _lastDotTicks = Time.Ticks;

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
@@ -67,8 +67,8 @@ namespace ClassicUO.Game.UI.Gumps.Login
             // Background
             UIManager.Add(new LoginBackground());
 
-            const int LogoMaxWidth = 750;
-            const int LogoMaxHeight = 131;
+            const int LogoMaxWidth = 900;
+            const int LogoMaxHeight = 200;
             if (LogoBackgroundImg != null)
             {
                 float scale = Math.Min((float)LogoMaxWidth / LogoBackgroundImg.Width, (float)LogoMaxHeight / LogoBackgroundImg.Height);

--- a/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
@@ -49,7 +49,7 @@ namespace ClassicUO.Game.UI.Gumps
     {
         private readonly Action<bool> _action;
 
-        public MessageBoxGump(int w, int h, string message, Action<bool> action, bool hasBackground = false, MessageButtonType menuType = MessageButtonType.OK) : base(0, 0)
+        public MessageBoxGump(int w, int h, string message, Action<bool> action, bool hasBackground = false, MessageButtonType menuType = MessageButtonType.OK, ushort messageHue = 0x0481) : base(0, 0)
         {
             CanMove = true;
             CanCloseWithRightClick = false;
@@ -92,7 +92,7 @@ namespace ClassicUO.Game.UI.Gumps
                 (
                     message,
                     false,
-                    0x0481,
+                    messageHue,
                     Width - 90,
                     1
                 )

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -55,6 +55,8 @@ namespace ClassicUO.Game.UI.Gumps
             _leftMouseIsDown,
             _isLastTarget,
             _needsNameUpdate;
+        private bool _hasBarsBelow;
+        private bool _lastNamePlateHealthBar;
         private UOLabel _text;
         private Texture2D _borderColor = SolidColorTextureCache.GetTexture(Color.Black);
         private Vector2 _textDrawOffset = Vector2.Zero;
@@ -173,6 +175,7 @@ namespace ClassicUO.Game.UI.Gumps
                 _textDrawOffset.X = (Width - _text.Width - 4) >> 1;
                 _textDrawOffset.Y = hasOtherBarBelow || hasSelfBarsBelow ? 0 : (Height - _text.Height) >> 1;
                 WantUpdateSize = false;
+                _lastNamePlateHealthBar = ProfileManager.CurrentProfile.NamePlateHealthBar;
 
                 return true;
             }
@@ -511,6 +514,11 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else
             {
+                if (ProfileManager.CurrentProfile != null && _background != null)
+                {
+                    _background.Alpha = ProfileManager.CurrentProfile.NamePlateOpacity / 100f;
+                }
+
                 if (entity.Serial == TargetManager.LastTargetInfo.Serial && !entity.Equals(World.Player))
                 {
                     if (!_isLastTarget) //Only set this if it was not already last target
@@ -534,6 +542,16 @@ namespace ClassicUO.Game.UI.Gumps
                 if (_needsNameUpdate)
                 {
                     SetName();
+                }
+
+                if (entity is Mobile && ProfileManager.CurrentProfile != null)
+                {
+                    bool curBar = ProfileManager.CurrentProfile.NamePlateHealthBar;
+                    if (curBar != _lastNamePlateHealthBar)
+                    {
+                        _lastNamePlateHealthBar = curBar;
+                        SetName();
+                    }
                 }
             }
         }
@@ -584,23 +602,20 @@ namespace ClassicUO.Game.UI.Gumps
                 _hpPercent = (double)m.Hits / (double)m.HitsMax;
 
                 IsVisible = true;
+
+                bool onlyWarMode = ProfileManager.CurrentProfile.NamePlateHideAtFullHealthInWarmode;
+                bool playerInWar = World.Player != null && World.Player.InWarMode;
+
+                if (onlyWarMode && !playerInWar)
+                {
+                    IsVisible = false;
+                    return false;
+                }
+
                 if (ProfileManager.CurrentProfile.NamePlateHideAtFullHealth && _hpPercent >= 1)
                 {
-                    if (ProfileManager.CurrentProfile.NamePlateHideAtFullHealthInWarmode)
-                    {
-                        if (World.Player.InWarMode)
-                        {
-                            IsVisible = false;
-                            return false;
-                        }
-
-                    }
-                    else
-                    {
-                        IsVisible = false;
-                        return false;
-                    }
-
+                    IsVisible = false;
+                    return false;
                 }
 
                 Client.Game.Animations.GetAnimationDimensions(

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -56,6 +56,7 @@ namespace ClassicUO.Game.UI.Gumps
             _isLastTarget,
             _needsNameUpdate;
         private bool _hasBarsBelow;
+        private bool _otherPlayerSingleHpBar;
         private bool _lastNamePlateHealthBar;
         private UOLabel _text;
         private Texture2D _borderColor = SolidColorTextureCache.GetTexture(Color.Black);
@@ -77,6 +78,75 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 currentHeight = value;
             }
+        }
+
+        public static int GetFloatingTextVerticalReserve(uint serial)
+        {
+            if (!NameOverHeadManager.IsShowing)
+            {
+                return 0;
+            }
+
+            NameOverheadGump g = UIManager.GetGump<NameOverheadGump>(serial);
+
+            if (g == null || g.IsDisposed || !g._hasBarsBelow)
+            {
+                return 0;
+            }
+
+            if (g.NamePlateSuppressedByProfile())
+            {
+                return 0;
+            }
+
+            int h = g.Height;
+            int nameH = g._text != null ? g._text.Height : 18;
+            if (g._otherPlayerSingleHpBar)
+            {
+                int pull = 36;
+                int target = h - pull;
+                int floor = Math.Max(10, nameH - 6);
+                return Math.Max(floor, target);
+            }
+
+            int pullCloser = 28;
+            int t2 = h - pullCloser;
+            int floor2 = Math.Max(12, nameH);
+            return Math.Max(floor2, t2);
+        }
+
+        private bool NamePlateSuppressedByProfile()
+        {
+            if (!SerialHelper.IsMobile(LocalSerial))
+            {
+                return false;
+            }
+
+            Mobile m = World.Mobiles.Get(LocalSerial);
+
+            if (m == null)
+            {
+                return true;
+            }
+
+            Profile current = ProfileManager.CurrentProfile;
+
+            if (current == null)
+            {
+                return false;
+            }
+
+            if (current.NamePlateHideAtFullHealthInWarmode && !(World.Player != null && World.Player.InWarMode))
+            {
+                return true;
+            }
+
+            if (current.NamePlateHideAtFullHealth && m.HitsMax > 0 && m.Hits >= m.HitsMax)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public NameOverheadGump(uint serial) : base(serial, 0)
@@ -149,6 +219,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 Width = _background.Width = _text.Width + 4;
                 Height = _background.Height = CurrentHeight = _text.Height;
+                _hasBarsBelow = false;
+                _otherPlayerSingleHpBar = false;
                 _textDrawOffset.X = (Width - _text.Width - 4) >> 1;
                 _textDrawOffset.Y = (Height - _text.Height) >> 1;
                 WantUpdateSize = false;
@@ -169,6 +241,8 @@ namespace ClassicUO.Game.UI.Gumps
                     && ProfileManager.CurrentProfile.NamePlateHealthBar;
                 bool hasSelfBarsBelow = isSelfOrParty && ProfileManager.CurrentProfile.NamePlateHealthBar;
                 int barExtra = hasOtherBarBelow ? 8 : hasSelfBarsBelow ? 20 : 0;
+                _hasBarsBelow = hasOtherBarBelow || hasSelfBarsBelow;
+                _otherPlayerSingleHpBar = hasOtherBarBelow;
                 Width = _background.Width = _text.Width + 4;
                 Height = _background.Height = baseHeight + barExtra;
                 CurrentHeight = Height;

--- a/src/ClassicUO.Client/Game/UI/Gumps/NearbyItems.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NearbyItems.cs
@@ -3,217 +3,571 @@ using System.Collections.Generic;
 using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    internal class NearbyItems : Gump
+    internal class NearbyItems : ResizableGump
     {
-        public const int SIZE = 75;
+        private const int X_SPACING = 1;
+        private const int Y_SPACING = 1;
         private const int PADDING = 10;
-        private const int TITLE_HEIGHT = 22;
+        private const int Title_H = 24;
+        private const int SentinelPos = -50000;
 
         public static NearbyItems NearbyItemGump;
-        private AlphaBlendControl _panel;
 
-        public NearbyItems() : base(0, 0)
+        private readonly List<Item> _items;
+        private readonly AlphaBlendControl _bg;
+        private readonly GumpPicTiled _bgTex;
+        private readonly Label _title;
+        private readonly Line _line;
+        private readonly ScrollArea _scroll;
+        private int _innerBorder = 4;
+        private int _lastGridBorderStyle = int.MinValue;
+        private float _lastContainerOpacity = -1f;
+        private ushort _lastAltHue = ushort.MaxValue;
+
+        public static bool TryOpen()
         {
             if (NearbyItemGump != null)
-                NearbyItemGump.Dispose();
+            {
+                return true;
+            }
 
-            NearbyItemGump = this;
+            List<Item> list = CollectNearbyItems();
+            if (list.Count == 0)
+            {
+                return false;
+            }
 
-            CanMove = true;
-            CanCloseWithRightClick = true;
-
-            BuildGump();
-
-            X = Mouse.Position.X - (Width / 2);
-            Y = Mouse.Position.Y - (Height / 2);
+            UIManager.Add(new NearbyItems(list));
+            return true;
         }
 
-        private void BuildGump()
+        private static List<Item> CollectNearbyItems()
         {
-            List<NearbyItemDisplay> items = new List<NearbyItemDisplay>();
-
+            List<Item> list = new List<Item>();
             foreach (Item i in World.Items.Values)
             {
-                if (!i.OnGround) continue;
-
-                if (i.Distance > Constants.DRAG_ITEMS_DISTANCE) continue;
-
-                if (i.IsLocked && !i.ItemData.IsContainer) continue;
-
-                items.Add(new NearbyItemDisplay(i));
-            }
-
-            if (items.Count == 0)
-            {
-                Dispose();
-                return;
-            }
-
-            int gridSize = (int)Math.Ceiling(Math.Sqrt(items.Count));
-            int gridW = gridSize * SIZE;
-            int gridH = gridSize * SIZE;
-            int totalW = PADDING * 2 + gridW;
-            int totalH = PADDING + TITLE_HEIGHT + PADDING + gridH + PADDING;
-
-            _panel = new AlphaBlendControl(0.92f)
-            {
-                X = 0,
-                Y = 0,
-                Width = totalW,
-                Height = totalH
-            };
-            Add(_panel);
-
-            Add(new Label("Items nearby", true, 1, 0) { X = PADDING, Y = PADDING + 2 });
-
-            int gridX = PADDING;
-            int gridY = PADDING + TITLE_HEIGHT + PADDING;
-            int ii = 0;
-            for (int row = 0; row < gridSize; row++)
-            {
-                for (int col = 0; col < gridSize; col++)
+                if (!i.OnGround)
                 {
-                    if (ii >= items.Count) break;
-
-                    items[ii].X = gridX + col * SIZE;
-                    items[ii].Y = gridY + row * SIZE;
-                    Add(items[ii]);
-                    ii++;
+                    continue;
                 }
+
+                if (i.Distance > Constants.DRAG_ITEMS_DISTANCE)
+                {
+                    continue;
+                }
+
+                if (i.IsLocked && !i.ItemData.IsContainer)
+                {
+                    continue;
+                }
+
+                list.Add(i);
             }
 
-            Width = totalW;
-            Height = totalH;
+            return list;
+        }
+
+        private static int GridSlotSize()
+        {
+            return Math.Max(1, (int)Math.Round(50.0 * ProfileManager.CurrentProfile.GridContainersScale / 100.0));
+        }
+
+        private static int ActionStripH(int g)
+        {
+            return Math.Max(18, Math.Min(24, g * 2 / 5));
+        }
+
+        private static int SlotRowPitch()
+        {
+            int g = GridSlotSize();
+            return g + ActionStripH(g) + Y_SPACING;
+        }
+
+        private static int InnerBorderW()
+        {
+            switch ((GridContainer.BorderStyle)ProfileManager.CurrentProfile.Grid_BorderStyle)
+            {
+                case GridContainer.BorderStyle.Style1:
+                    return 26;
+                case GridContainer.BorderStyle.Style2:
+                    return 12;
+                case GridContainer.BorderStyle.Style3:
+                    return 10;
+                case GridContainer.BorderStyle.Style4:
+                    return 7;
+                case GridContainer.BorderStyle.Style5:
+                    return 10;
+                case GridContainer.BorderStyle.Style6:
+                    return 4;
+                case GridContainer.BorderStyle.Style7:
+                    return 17;
+                case GridContainer.BorderStyle.Style8:
+                    return 16;
+                default:
+                    return 4;
+            }
+        }
+
+        private static int MinWidthPx()
+        {
+            int g = GridSlotSize();
+            int bw = InnerBorderW();
+            return bw * 2 + 14 + g + X_SPACING;
+        }
+
+        private static int MinShrinkHeight()
+        {
+            int bw = InnerBorderW();
+            return bw * 2 + PADDING + Title_H + 8 + SlotRowPitch() + 8;
+        }
+
+        private static int ContentHeightForWidth(List<Item> items, int widthPx)
+        {
+            int g = GridSlotSize();
+            int bw = InnerBorderW();
+            int inner = widthPx - bw * 2 - 14;
+            int cols = Math.Max(1, (inner + X_SPACING) / (g + X_SPACING));
+            int rows = Math.Max(1, (items.Count + cols - 1) / cols);
+            return bw * 2 + PADDING + Title_H + 8 + rows * SlotRowPitch() - Y_SPACING + 8;
+        }
+
+        private static int InitialWidth(List<Item> items)
+        {
+            int g = GridSlotSize();
+            int bw = InnerBorderW();
+            int min6 = bw * 2 + 14 + 6 * (g + X_SPACING) - X_SPACING;
+            int saved = ProfileManager.CurrentProfile.NearbyItemsGumpSize.X;
+            return Math.Max(Math.Max(640, min6), saved >= MinWidthPx() ? saved : 640);
+        }
+
+        private static int InitialHeight(List<Item> items, int widthPx)
+        {
+            int ch = ContentHeightForWidth(items, widthPx);
+            int saved = ProfileManager.CurrentProfile.NearbyItemsGumpSize.Y;
+            int target = saved >= MinShrinkHeight() ? saved : 440;
+            return Math.Max(MinShrinkHeight(), Math.Min(ch, target));
+        }
+
+        private NearbyItems(List<Item> items) : base(
+            InitialWidth(items),
+            InitialHeight(items, InitialWidth(items)),
+            MinWidthPx(),
+            MinShrinkHeight(),
+            0,
+            0)
+        {
+            _items = items;
+            NearbyItemGump = this;
+            AnchorType = ANCHOR_TYPE.DISABLED;
+            CanMove = true;
+            _prevCanMove = true;
+            AcceptMouseInput = true;
+            CanCloseWithRightClick = true;
+            ShowBorder = true;
+            _prevBorder = true;
+            _prevCloseWithRightClick = true;
+            CanBeLocked = false;
+
+            Insert(0, _bg = new AlphaBlendControl());
+            Insert(1, _bgTex = new GumpPicTiled(0));
+            Add(_title = new Label("Items nearby", true, 0x0481, 0, 1));
+            Add(_line = new Line(0, 0, 100, 1, 0xFF7a6a5a));
+            _scroll = new ScrollArea(0, 0, 100, 100, true);
+            _scroll.CanMove = false;
+            Add(_scroll);
+
+            ApplySavedPosition();
+            SyncPanelChrome(true);
+        }
+
+        private void ApplySavedPosition()
+        {
+            Point p = ProfileManager.CurrentProfile.NearbyItemsGumpPosition;
+            if (p.X <= SentinelPos || p.Y <= SentinelPos)
+            {
+                X = Mouse.Position.X - (Width >> 1);
+                Y = Mouse.Position.Y - (Height >> 1);
+            }
+            else
+            {
+                X = p.X;
+                Y = p.Y;
+            }
+        }
+
+        private void ApplyGridPanelBorderStyle()
+        {
+            int graphic = 0;
+            int borderSize = 0;
+            switch ((GridContainer.BorderStyle)ProfileManager.CurrentProfile.Grid_BorderStyle)
+            {
+                case GridContainer.BorderStyle.Style1:
+                    graphic = 3500;
+                    borderSize = 26;
+                    break;
+                case GridContainer.BorderStyle.Style2:
+                    graphic = 5054;
+                    borderSize = 12;
+                    break;
+                case GridContainer.BorderStyle.Style3:
+                    graphic = 5120;
+                    borderSize = 10;
+                    break;
+                case GridContainer.BorderStyle.Style4:
+                    graphic = 9200;
+                    borderSize = 7;
+                    break;
+                case GridContainer.BorderStyle.Style5:
+                    graphic = 9270;
+                    borderSize = 10;
+                    break;
+                case GridContainer.BorderStyle.Style6:
+                    graphic = 9300;
+                    borderSize = 4;
+                    break;
+                case GridContainer.BorderStyle.Style7:
+                    graphic = 9260;
+                    borderSize = 17;
+                    break;
+                case GridContainer.BorderStyle.Style8:
+                    if (Client.Game.Gumps.GetGump(40303).Texture != null)
+                    {
+                        graphic = 40303;
+                    }
+                    else
+                    {
+                        graphic = 83;
+                    }
+
+                    borderSize = 16;
+                    break;
+                default:
+                case GridContainer.BorderStyle.Default:
+                    BorderControl.DefaultGraphics();
+                    _bgTex.IsVisible = false;
+                    _bg.IsVisible = true;
+                    _innerBorder = 4;
+                    BorderControl.IsVisible = !ProfileManager.CurrentProfile.Grid_HideBorder;
+                    return;
+            }
+
+            BorderControl.T_Left = (ushort)graphic;
+            BorderControl.H_Border = (ushort)(graphic + 1);
+            BorderControl.T_Right = (ushort)(graphic + 2);
+            BorderControl.V_Border = (ushort)(graphic + 3);
+            _bgTex.Graphic = (ushort)(graphic + 4);
+            _bgTex.IsVisible = true;
+            _bg.IsVisible = false;
+            BorderControl.V_Right_Border = (ushort)(graphic + 5);
+            BorderControl.B_Left = (ushort)(graphic + 6);
+            BorderControl.H_Bottom_Border = (ushort)(graphic + 7);
+            BorderControl.B_Right = (ushort)(graphic + 8);
+            BorderControl.BorderSize = borderSize;
+            _innerBorder = borderSize;
+            BorderControl.IsVisible = !ProfileManager.CurrentProfile.Grid_HideBorder;
+        }
+
+        private void SyncPanelChrome(bool reflowGrid)
+        {
+            float op = (float)ProfileManager.CurrentProfile.ContainerOpacity / 100f;
+            ushort hue = ProfileManager.CurrentProfile.AltGridContainerBackgroundHue;
+            _bg.Alpha = op;
+            _bg.Hue = hue;
+            ApplyGridPanelBorderStyle();
+            _bgTex.Alpha = op;
+            _bgTex.Hue = hue;
+            BorderControl.Hue = hue;
+            BorderControl.Alpha = op;
+
+            int bw = _innerBorder;
+            int headerH = PADDING + Title_H + 8;
+            _bg.X = bw;
+            _bg.Y = bw;
+            _bg.Width = Width - bw * 2;
+            _bg.Height = Height - bw * 2;
+            _bgTex.X = bw;
+            _bgTex.Y = bw;
+            _bgTex.Width = _bg.Width;
+            _bgTex.Height = _bg.Height;
+            _title.X = bw + 4;
+            _title.Y = bw + 4;
+            _line.X = bw;
+            _line.Y = bw + PADDING + Title_H + 2;
+            _line.Width = Math.Max(20, Width - bw * 2);
+            _scroll.X = bw;
+            _scroll.Y = bw + headerH;
+            _scroll.Width = Math.Max(MinWidthPx() - bw * 2, Width - bw * 2);
+            _scroll.Height = Math.Max(80, Height - bw * 2 - headerH);
+            _scroll.UpdateScrollbarPosition();
+            if (reflowGrid)
+            {
+                ReflowGrid();
+            }
+        }
+
+        private void ReflowGrid()
+        {
+            _scroll.Clear();
+            int g = GridSlotSize();
+            int sh = ActionStripH(g);
+            int innerW = _scroll.Width - 14;
+            int cols = Math.Max(1, (innerW + X_SPACING) / (g + X_SPACING));
+            int pitch = g + sh + Y_SPACING;
+            for (int i = 0; i < _items.Count; i++)
+            {
+                int col = i % cols;
+                int row = i / cols;
+                NearbyGridSlot slot = new NearbyGridSlot(_items[i], g, sh);
+                slot.X = col * (g + X_SPACING);
+                slot.Y = row * pitch;
+                _scroll.Add(slot);
+            }
         }
 
         public override void Update()
         {
+            Profile p = ProfileManager.CurrentProfile;
+            if (_lastGridBorderStyle != p.Grid_BorderStyle
+                || Math.Abs(_lastContainerOpacity - p.ContainerOpacity) > 0.01f
+                || _lastAltHue != p.AltGridContainerBackgroundHue)
+            {
+                _lastGridBorderStyle = p.Grid_BorderStyle;
+                _lastContainerOpacity = p.ContainerOpacity;
+                _lastAltHue = p.AltGridContainerBackgroundHue;
+                SyncPanelChrome(true);
+            }
+
             base.Update();
-            if (!Keyboard.Ctrl)
-                Dispose();
+        }
+
+        public override void OnResize()
+        {
+            base.OnResize();
+            if (_scroll != null)
+            {
+                SyncPanelChrome(true);
+                ProfileManager.CurrentProfile.NearbyItemsGumpSize = new Point(Width, Height);
+            }
+        }
+
+        protected override void OnDragEnd(int x, int y)
+        {
+            ProfileManager.CurrentProfile.NearbyItemsGumpPosition = Location;
+            base.OnDragEnd(x, y);
         }
 
         public override void Dispose()
         {
-            base.Dispose();
+            if (!IsDisposed && NearbyItemGump == this)
+            {
+                ProfileManager.CurrentProfile.NearbyItemsGumpSize = new Point(Width, Height);
+                ProfileManager.CurrentProfile.NearbyItemsGumpPosition = Location;
+            }
+
             NearbyItemGump = null;
+            base.Dispose();
         }
     }
 
-    internal class NearbyItemDisplay : Control
+    internal class NearbyGridSlot : Control
     {
-        private readonly Item item;
-        private Point originalSize;
-        private float scale = (ProfileManager.CurrentProfile.GridContainersScale / 100f);
-        private Vector3 hueVector;
-        private Rectangle realArtRectBounds;
-        private Point point = new Point();
-        private readonly SpriteInfo itemSpriteInfo;
-        private readonly AlphaBlendControl background;
+        private readonly Item _item;
+        private readonly int _g;
+        private readonly int _stripH;
+        private readonly HitBox _itemHit;
+        private readonly Rectangle _rect;
+        private readonly Rectangle _bounds;
+        private readonly Texture2D _texture;
 
-
-        public NearbyItemDisplay(Item item)
+        public NearbyGridSlot(Item item, int gridSize, int stripH)
         {
-            Width = NearbyItems.SIZE;
-            Height = NearbyItems.SIZE;
-            background = new AlphaBlendControl() { Width = Width, Height = Height };
-            originalSize = new Point(Width, Height);
-            this.item = item;
-            hueVector = ShaderHueTranslator.GetHueVector(item.Hue, item.ItemData.IsPartialHue, 1f);
-            realArtRectBounds = Client.Game.Arts.GetRealArtBounds((uint)item.DisplayedGraphic);
-            itemSpriteInfo = Client.Game.Arts.GetArt((uint)(item.DisplayedGraphic));
+            _item = item;
+            _g = gridSize;
+            _stripH = stripH;
+            Width = _g;
+            Height = _g + _stripH;
 
-            HitBox loot = new HitBox(0, 0, Width, Height / 2);
-            loot.Add(new UOLabel("Loot", 1, UOLabelHue.Text, Assets.TEXT_ALIGN_TYPE.TS_CENTER, Width));
-            loot.MouseDown += (s, e) =>
+            AlphaBlendControl slotFill = new AlphaBlendControl(0.25f)
             {
-                GameActions.GrabItem(item, item.Amount);
-                Dispose();
+                X = 0,
+                Y = 0,
+                Width = _g,
+                Height = _g
+            };
+            Add(slotFill);
+
+            AlphaBlendControl stripFill = new AlphaBlendControl(0.25f)
+            {
+                X = 0,
+                Y = _g,
+                Width = _g,
+                Height = _stripH
+            };
+            Add(stripFill);
+
+            Add(_itemHit = new HitBox(0, 0, _g, _g, null, 0f));
+            _itemHit.SetTooltip(item);
+
+            ref readonly SpriteInfo text = ref Client.Game.Arts.GetArt((uint)item.DisplayedGraphic);
+            _texture = text.Texture;
+            _bounds = text.UV;
+            _rect = Client.Game.Arts.GetRealArtBounds((uint)item.DisplayedGraphic);
+
+            int itemAmt = item.ItemData.IsStackable ? item.Amount : 1;
+            if (itemAmt > 1)
+            {
+                Label count = new Label(itemAmt.ToString(), true, 0x0481, align: TEXT_ALIGN_TYPE.TS_LEFT)
+                {
+                    X = 1,
+                    Y = _g - 14
+                };
+                Add(count);
+            }
+
+            int half = _g >> 1;
+            HitBox loot = new HitBox(0, _g, half, _stripH);
+            loot.Add(new UOLabel("Loot", 1, UOLabelHue.Text, TEXT_ALIGN_TYPE.TS_CENTER, half));
+            loot.MouseDown += (_, e) =>
+            {
+                if (e.Button == MouseButtonType.Left)
+                {
+                    GameActions.GrabItem(_item, _item.Amount);
+                    NearbyItems.NearbyItemGump?.Dispose();
+                }
             };
             Add(loot);
 
-            HitBox use = new HitBox(0, Height / 2, Width, Height / 2);
-            UOLabel tb;
-            use.Add(tb = new UOLabel("Use", 1, UOLabelHue.Text, Assets.TEXT_ALIGN_TYPE.TS_CENTER, Width));
-            tb.Y = use.Height - tb.Height;
-            use.MouseDown += (s, e) =>
+            HitBox use = new HitBox(half, _g, half, _stripH);
+            UOLabel ul;
+            use.Add(ul = new UOLabel("Use", 1, UOLabelHue.Text, TEXT_ALIGN_TYPE.TS_CENTER, half));
+            ul.Y = (_stripH - ul.Height) >> 1;
+            use.MouseDown += (_, e) =>
             {
-                GameActions.DoubleClick(item);
+                if (e.Button == MouseButtonType.Left)
+                {
+                    GameActions.DoubleClick(_item);
+                }
             };
             Add(use);
 
-
-            if (realArtRectBounds.Width < Width)
-            {
-                if (ProfileManager.CurrentProfile.GridContainerScaleItems)
-                    originalSize.X = (ushort)(realArtRectBounds.Width * scale);
-                else
-                    originalSize.X = realArtRectBounds.Width;
-
-                point.X = (Width >> 1) - (originalSize.X >> 1);
-            }
-            else if (realArtRectBounds.Width > Width)
-            {
-                if (ProfileManager.CurrentProfile.GridContainerScaleItems)
-                    originalSize.X = (ushort)(Width * scale);
-                else
-                    originalSize.X = Width;
-                point.X = (Width >> 1) - (originalSize.X >> 1);
-            }
-
-            if (realArtRectBounds.Height < Height)
-            {
-                if (ProfileManager.CurrentProfile.GridContainerScaleItems)
-                    originalSize.Y = (ushort)(realArtRectBounds.Height * scale);
-                else
-                    originalSize.Y = realArtRectBounds.Height;
-
-                point.Y = (Height >> 1) - (originalSize.Y >> 1);
-            }
-            else if (realArtRectBounds.Height > Height)
-            {
-                if (ProfileManager.CurrentProfile.GridContainerScaleItems)
-                    originalSize.Y = (ushort)(Height * scale);
-                else
-                    originalSize.Y = Height;
-
-                point.Y = (Height >> 1) - (originalSize.Y >> 1);
-            }
+            Add(new Line(0, _g, _g, 1, 0xFF6a6a6a));
+            Add(new Line(half, _g, 1, _stripH, 0xFF6a6a6a));
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
-            background.Draw(batcher, x, y);
-
-            batcher.Draw
-            (
-                itemSpriteInfo.Texture,
-                new Rectangle
-                (
-                    x + point.X,
-                    y + point.Y,
-                    originalSize.X,
-                    originalSize.Y
-            ),
-            new Rectangle
-            (
-                    itemSpriteInfo.UV.X + realArtRectBounds.X,
-                    itemSpriteInfo.UV.Y + realArtRectBounds.Y,
-                    realArtRectBounds.Width,
-                    realArtRectBounds.Height
-                ),
-                hueVector
-            );
-
             base.Draw(batcher, x, y);
+
+            Vector3 borderVec = ShaderHueTranslator.GetHueVector(
+                ProfileManager.CurrentProfile.GridBorderHue,
+                false,
+                (float)ProfileManager.CurrentProfile.GridBorderAlpha / 100);
+            batcher.DrawRectangle(SolidColorTextureCache.GetTexture(Color.White), x, y, _g, _g, borderVec);
+            batcher.DrawRectangle(SolidColorTextureCache.GetTexture(Color.White), x, y + _g, _g, _stripH, borderVec);
+
+            if (_itemHit.MouseIsOver && _item != null)
+            {
+                Vector3 h = ShaderHueTranslator.GetHueVector(0, false, 1f);
+                h.Z = 0.3f;
+                batcher.Draw(
+                    SolidColorTextureCache.GetTexture(Color.White),
+                    new Rectangle(x + 1, y, _g - 1, _g),
+                    h);
+            }
+
+            if (_item != null && _texture != null && _rect.Width > 0 && _rect.Height > 0)
+            {
+                Vector3 hueVector = ShaderHueTranslator.GetHueVector(_item.Hue, _item.ItemData.IsPartialHue, 1f);
+                Point originalSize = new Point(_g, _g);
+                Point point = new Point();
+                float scale = ProfileManager.CurrentProfile.GridContainersScale / 100f;
+
+                if (_rect.Width < _g)
+                {
+                    if (ProfileManager.CurrentProfile.GridContainerScaleItems)
+                    {
+                        originalSize.X = (ushort)(_rect.Width * scale);
+                    }
+                    else
+                    {
+                        originalSize.X = _rect.Width;
+                    }
+
+                    point.X = (_g >> 1) - (originalSize.X >> 1);
+                }
+                else if (_rect.Width > _g)
+                {
+                    if (ProfileManager.CurrentProfile.GridContainerScaleItems)
+                    {
+                        originalSize.X = (ushort)(_g * scale);
+                    }
+                    else
+                    {
+                        originalSize.X = _g;
+                    }
+
+                    point.X = (_g >> 1) - (originalSize.X >> 1);
+                }
+
+                if (_rect.Height < _g)
+                {
+                    if (ProfileManager.CurrentProfile.GridContainerScaleItems)
+                    {
+                        originalSize.Y = (ushort)(_rect.Height * scale);
+                    }
+                    else
+                    {
+                        originalSize.Y = _rect.Height;
+                    }
+
+                    point.Y = (_g >> 1) - (originalSize.Y >> 1);
+                }
+                else if (_rect.Height > _g)
+                {
+                    if (ProfileManager.CurrentProfile.GridContainerScaleItems)
+                    {
+                        originalSize.Y = (ushort)(_g * scale);
+                    }
+                    else
+                    {
+                        originalSize.Y = _g;
+                    }
+
+                    point.Y = (_g >> 1) - (originalSize.Y >> 1);
+                }
+
+                if (ProfileManager.CurrentProfile.EnlargeJewelryOnPaperdoll
+                    && (_item.ItemData.Layer == (byte)Layer.Ring || _item.ItemData.Layer == (byte)Layer.Bracelet))
+                {
+                    bool isBracelet = _item.ItemData.Layer == (byte)Layer.Bracelet;
+                    float jMult = isBracelet ? 1.55f : 1.8f;
+                    int jMin = isBracelet ? 8 : 9;
+                    int pad = 2;
+                    int jw = Math.Min(_g - pad, Math.Max(jMin, (int)Math.Ceiling(_rect.Width * jMult)));
+                    int jh = Math.Min(_g - pad, Math.Max(jMin, (int)Math.Ceiling(_rect.Height * jMult)));
+                    originalSize.X = jw;
+                    originalSize.Y = jh;
+                    point.X = (_g >> 1) - (jw >> 1);
+                    point.Y = (_g >> 1) - (jh >> 1);
+                }
+
+                batcher.Draw(
+                    _texture,
+                    new Rectangle(x + point.X, y + point.Y, originalSize.X, originalSize.Y),
+                    new Rectangle(_bounds.X + _rect.X, _bounds.Y + _rect.Y, _rect.Width, _rect.Height),
+                    hueVector);
+            }
 
             return true;
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.ActionBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.ActionBar.cs
@@ -30,7 +30,7 @@ namespace ClassicUO.Game.UI.Gumps
                     profile.ActionBarSlots.Add(new ActionBarSlotData());
             }
 
-            ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 550, true);
+            ScrollArea rightArea = new ScrollArea(190, OptionsScrollY, WIDTH - 210, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
             int startX = 5;
             int startY = 5;

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -66,6 +66,12 @@ namespace ClassicUO.Game.UI.Gumps
         private static int WIDTH => LoginLayoutHelper.OptionsWidth;
         private static int HEIGHT => LoginLayoutHelper.OptionsHeight;
         private const int TEXTBOX_HEIGHT = 25;
+        private const int OptionsTabStartY = 10;
+        private const int OptionsSearchRowHeight = 26;
+        private const int OptionsSearchToContentGap = 2;
+        private static int OptionsScrollY =>
+            OptionsTabStartY + OptionsSearchRowHeight + OptionsSearchToContentGap;
+        private static int OptionsScrollHeight => HEIGHT - 60 - OptionsScrollY;
         private static readonly string[] WINDOW_TITLE_STYLE_LABELS =
         {
             "Like CUO (native)",
@@ -210,7 +216,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Checkbox _titleBarStatsModePercent;
         private Checkbox _titleBarStatsModeProgressBar;
         // ## BEGIN - END ## // ART / HUE CHANGES
-        private Checkbox _colorStealth, _colorEnergyBolt, _colorGold, _colorTreeTile, _colorBlockerTile;
+        private Checkbox _colorStealth, _colorEnergyBolt, _colorGold, _colorTreeTile, _colorBlockerTile, _enlargeJewelryPaperdoll;
         private ModernColorPicker.HueDisplay _stealthColorPickerBox, _energyBoltColorPickerBox, _goldColorPickerBox, _treeTileColorPickerBox, _blockerTileColorPickerBox;
         private Combobox _goldType, _treeType, _blockerType, _stealthNeonType, _energyBoltNeonType, _energyBoltArtType;
         // ## BEGIN - END ## // ART / HUE CHANGES
@@ -239,7 +245,7 @@ namespace ClassicUO.Game.UI.Gumps
         private InputField _SpecialSetLastTargetClilocText, _blockWoSArt, _blockEnergyFArt;
         // ## BEGIN - END ## // MISC
         // ## BEGIN - END ## // MISC2
-        private Checkbox _wireframeView, _hueImpassableView, _transparentHouses, _invisibleHouses, _ignoreCoT, _showDeathOnWorldmap, _showMapCloseFriend, _drawMobilesWithSurfaceOverhead, _autoAvoidMobiles, _scaleMonstersEnabled, _forceGargoyleWalk;
+        private Checkbox _wireframeView, _hueImpassableView, _transparentHouses, _invisibleHouses, _ignoreCoT, _showDeathOnWorldmap, _drawMobilesWithSurfaceOverhead, _autoAvoidMobiles, _scaleMonstersEnabled, _forceGargoyleWalk;
         private HSliderBar _transparentHousesZ, _transparentHousesTransparency, _invisibleHousesZ, _dontRemoveHouseBelowZ;
         // ## BEGIN - END ## // MISC2
         // ## BEGIN - END ## // MACROS
@@ -325,6 +331,13 @@ namespace ClassicUO.Game.UI.Gumps
         private Profile _currentProfile = ProfileManager.CurrentProfile;
         private OptionsGumpLanguage _lang = Language.Instance.GetOptionsGumpLanguage;
         private Dust765Language _langDust = Language.Instance.GetDust765;
+        private InputField _optionsSearchField;
+        private Label _optionsSearchLabel;
+        private GothicStyleButton _optionsSearchClearBtn;
+        private GothicStyleButton _optionsSearchSubmitBtn;
+        private string _optionsSearchAppliedTerm = string.Empty;
+        private readonly List<Control> _optionsSearchMatches = new List<Control>();
+        private readonly HashSet<int> _optionsSearchPagesWithHits = new HashSet<int>();
 
         public OptionsGump() : base(0, 0)
         {
@@ -343,12 +356,13 @@ namespace ClassicUO.Game.UI.Gumps
 
             int i = 0;
 
+            int tabY = OptionsTabStartY;
             Add
             (
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -362,7 +376,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -376,7 +390,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -390,7 +404,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -404,7 +418,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -418,7 +432,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -432,7 +446,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -446,7 +460,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -460,7 +474,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -474,7 +488,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -488,7 +502,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -502,7 +516,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -516,7 +530,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -530,7 +544,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.Activate,
@@ -542,9 +556,9 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             // ## BEGIN - END ## // BASICSETUP
-            Add(new NiceButton(10, 10 + 30 * i++, 140, 25, ButtonAction.SwitchPage, "Dust") { ButtonParameter = 16 });
-            Add(new NiceButton(10, 10 + 30 * i++, 140, 25, ButtonAction.SwitchPage, "765") { ButtonParameter = 17 });
-            Add(new NiceButton(10, 10 + 30 * i++, 140, 25, ButtonAction.SwitchPage, "Mods") { ButtonParameter = 18 });
+            Add(new NiceButton(10, tabY + 30 * i++, 140, 25, ButtonAction.SwitchPage, "Dust") { ButtonParameter = 16 });
+            Add(new NiceButton(10, tabY + 30 * i++, 140, 25, ButtonAction.SwitchPage, "765") { ButtonParameter = 17 });
+            Add(new NiceButton(10, tabY + 30 * i++, 140, 25, ButtonAction.SwitchPage, "Mods") { ButtonParameter = 18 });
             // ## BEGIN - END ## // BASICSETUP
 
             Add
@@ -552,7 +566,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -568,7 +582,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -584,7 +598,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -600,7 +614,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new NiceButton
                 (
                     10,
-                    10 + 30 * i++,
+                    tabY + 30 * i++,
                     140,
                     25,
                     ButtonAction.SwitchPage,
@@ -690,6 +704,238 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // BASICSETUP
 
             ChangePage(1);
+
+            const int searchFieldMaxW = 380;
+            int searchRowY = OptionsTabStartY + 1;
+            int contentLeft = 168;
+            _optionsSearchLabel = new Label("Search:", true, HUE_FONT, font: FONT)
+            {
+                X = contentLeft,
+                Y = searchRowY + 3
+            };
+            Add(_optionsSearchLabel, 0);
+            const int clearBtnW = 56;
+            const int searchBtnW = 78;
+            const int btnGap = 6;
+            int fieldX = _optionsSearchLabel.X + _optionsSearchLabel.Width + 10;
+            int fieldW = Math.Min(
+                searchFieldMaxW,
+                Math.Max(140, WIDTH - fieldX - clearBtnW - searchBtnW - btnGap * 2 - 12)
+            );
+            _optionsSearchField = new InputField(0x0BB8, FONT, HUE_FONT, true, fieldW, TEXTBOX_HEIGHT, 0, 256)
+            {
+                X = fieldX,
+                Y = searchRowY
+            };
+            Add(_optionsSearchField, 0);
+            int clearX = fieldX + fieldW + btnGap;
+            _optionsSearchClearBtn = new GothicStyleButton(clearX, searchRowY - 1, clearBtnW, TEXTBOX_HEIGHT + 2, "Clear");
+            _optionsSearchClearBtn.BaseColor = new Color(100, 100, 100);
+            _optionsSearchClearBtn.HighlightColor = new Color(155, 155, 155);
+            _optionsSearchClearBtn.ShadowColor = new Color(60, 60, 60);
+            _optionsSearchClearBtn.OnClick += ClearOptionsSearch;
+            Add(_optionsSearchClearBtn, 0);
+            _optionsSearchSubmitBtn = new GothicStyleButton(
+                clearX + clearBtnW + btnGap,
+                searchRowY - 1,
+                searchBtnW,
+                TEXTBOX_HEIGHT + 2,
+                "Search"
+            );
+            _optionsSearchSubmitBtn.BaseColor = new Color(100, 100, 100);
+            _optionsSearchSubmitBtn.HighlightColor = new Color(155, 155, 155);
+            _optionsSearchSubmitBtn.ShadowColor = new Color(60, 60, 60);
+            _optionsSearchSubmitBtn.OnClick += RunOptionsSearch;
+            Add(_optionsSearchSubmitBtn, 0);
+        }
+
+        private void ClearOptionsSearch()
+        {
+            if (_optionsSearchField != null)
+            {
+                _optionsSearchField.SetText(string.Empty);
+            }
+
+            _optionsSearchAppliedTerm = string.Empty;
+            _optionsSearchMatches.Clear();
+            _optionsSearchPagesWithHits.Clear();
+        }
+
+        private void RunOptionsSearch()
+        {
+            _optionsSearchAppliedTerm = _optionsSearchField?.Text?.Trim() ?? string.Empty;
+            RebuildOptionsSearchMatches();
+        }
+
+        private bool IsOptionsSearchChrome(Control c)
+        {
+            for (; c != null; c = c.Parent)
+            {
+                if (
+                    c == _optionsSearchField
+                    || c == _optionsSearchClearBtn
+                    || c == _optionsSearchSubmitBtn
+                    || c == _optionsSearchLabel
+                )
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private int OptionsSearchContentPage(Control c)
+        {
+            for (Control w = c; w != null; w = w.Parent)
+            {
+                if (w.Parent == this)
+                {
+                    return w.Page;
+                }
+            }
+
+            return 0;
+        }
+
+        private static void GetControlPositionInOptionsGump(OptionsGump gump, Control c, out int gx, out int gy)
+        {
+            if (c.Parent == gump)
+            {
+                gx = c.X;
+                gy = c.Y;
+                return;
+            }
+
+            GetControlPositionInOptionsGump(gump, c.Parent, out gx, out gy);
+            if (c.Parent is ScrollArea sa)
+            {
+                int idx = sa.Children.IndexOf(c);
+                if (idx > 0)
+                {
+                    gx += c.X;
+                    gy += c.Y - sa.ScrollValue + sa.ScissorRectangle.Y;
+                    return;
+                }
+            }
+
+            gx += c.X;
+            gy += c.Y;
+        }
+
+        private void RebuildOptionsSearchMatches()
+        {
+            _optionsSearchMatches.Clear();
+            _optionsSearchPagesWithHits.Clear();
+            if (_optionsSearchField == null || string.IsNullOrEmpty(_optionsSearchAppliedTerm) || _optionsSearchAppliedTerm.Length < 2)
+            {
+                return;
+            }
+
+            string term = _optionsSearchAppliedTerm;
+            CollectOptionsSearchMatches(this, term);
+        }
+
+        private void CollectOptionsSearchMatches(Control root, string term)
+        {
+            for (int i = 0; i < root.Children.Count; i++)
+            {
+                Control ch = root.Children[i];
+                if (ch == null || ch.IsDisposed)
+                {
+                    continue;
+                }
+
+                CollectOptionsSearchMatches(ch, term);
+            }
+
+            if (root == this || IsOptionsSearchChrome(root))
+            {
+                return;
+            }
+
+            if (root is Checkbox cb && !string.IsNullOrEmpty(cb.Text) && cb.Text.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _optionsSearchMatches.Add(root);
+                int pg = OptionsSearchContentPage(root);
+                if (pg > 0)
+                {
+                    _optionsSearchPagesWithHits.Add(pg);
+                }
+
+                return;
+            }
+
+            if (root is Label lb && lb.Text != null && lb.Text.Length >= 2 && lb.Text.IndexOf(term, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                _optionsSearchMatches.Add(root);
+                int pg = OptionsSearchContentPage(root);
+                if (pg > 0)
+                {
+                    _optionsSearchPagesWithHits.Add(pg);
+                }
+
+                return;
+            }
+
+            if (root is Combobox combo && combo.MatchesSearch(term))
+            {
+                _optionsSearchMatches.Add(root);
+                int pg = OptionsSearchContentPage(root);
+                if (pg > 0)
+                {
+                    _optionsSearchPagesWithHits.Add(pg);
+                }
+            }
+        }
+
+        private static ScrollArea FindOptionsSearchScrollParent(Control c)
+        {
+            Control w = c;
+            while (w?.Parent != null)
+            {
+                Control par = w.Parent;
+                if (par is ScrollArea sa && sa.Children.IndexOf(w) > 0)
+                {
+                    return sa;
+                }
+
+                w = par;
+            }
+
+            return null;
+        }
+
+        private bool OptionsSearchHighlightVisible(Control c, int gx, int gy, int bw, int bh)
+        {
+            ScrollArea sa = FindOptionsSearchScrollParent(c);
+            if (sa == null)
+            {
+                return true;
+            }
+
+            GetControlPositionInOptionsGump(this, sa, out int sx, out int sy);
+            int v0 = sy + sa.ScissorRectangle.Y;
+            int v1 = v0 + sa.Height;
+            if (gy + bh <= v0 || gy >= v1)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void DrawOptionsSearchHighlightBorder(UltimaBatcher2D batcher, Texture2D tex, Vector3 hueVec, int x, int y, int w, int h, int t)
+        {
+            if (w < 1 || h < 1)
+            {
+                return;
+            }
+
+            batcher.DrawRectangle(tex, x, y, w, t, hueVec);
+            batcher.DrawRectangle(tex, x, y + h - t, w, t, hueVec);
+            batcher.DrawRectangle(tex, x, y, t, h, hueVec);
+            batcher.DrawRectangle(tex, x + w - t, y, t, h, hueVec);
         }
 
         private static Texture2D LogoTexture
@@ -719,9 +965,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -1675,9 +1921,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -1796,9 +2042,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
 
@@ -2203,7 +2449,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             const int PAGE = 4;
 
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
 
             int startX = 5;
@@ -2445,9 +2691,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -2537,9 +2783,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -2607,9 +2853,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -2863,9 +3109,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -3096,9 +3342,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
 
@@ -3262,9 +3508,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -3338,9 +3584,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
@@ -3481,9 +3727,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
 
@@ -3662,7 +3908,8 @@ namespace ClassicUO.Game.UI.Gumps
         private void BuildNameOverhead()
         {
             const int PAGE = 13;
-            int topButtonY = 52 + 25 + 4;
+            int top = OptionsScrollY;
+            int topButtonY = top + 52 + 25 + 4;
             int bottomSeparatorY = HEIGHT - 51;
 
             ScrollArea rightArea = new ScrollArea
@@ -3679,7 +3926,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new Line
                 (
                     165,
-                    52 + 25 + 2,
+                    top + 52 + 25 + 2,
                     WIDTH - 165,
                     1,
                     Color.Gray.PackedValue
@@ -3692,9 +3939,9 @@ namespace ClassicUO.Game.UI.Gumps
                 new Line
                 (
                     165 + 150,
-                    21,
+                    top + 21,
                     1,
-                    bottomSeparatorY - 21,
+                    bottomSeparatorY - top - 21,
                     Color.Gray.PackedValue
                 ),
                 PAGE
@@ -3703,7 +3950,7 @@ namespace ClassicUO.Game.UI.Gumps
             NiceButton addButton = new NiceButton
             (
                 165,
-                20,
+                OptionsScrollY,
                 130,
                 20,
                 ButtonAction.Activate,
@@ -3716,7 +3963,7 @@ namespace ClassicUO.Game.UI.Gumps
             NiceButton delButton = new NiceButton
             (
                 165,
-                52,
+                OptionsScrollY + 32,
                 130,
                 20,
                 ButtonAction.Activate,
@@ -3877,7 +4124,7 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // TAZUO
             //ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
             // ## BEGIN - END ## // TAZUO
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
             // ## BEGIN - END ## // TAZUO
 
@@ -3889,7 +4136,7 @@ namespace ClassicUO.Game.UI.Gumps
             rightArea.Add(box);
 
             // ## BEGIN - END ## // UI/GUMPS
-            SettingsSection section = AddSettingsSection(box, "-----UI / Gumps-----");
+            SettingsSection section = AddSettingsSection(box, "UI GUMPS");
 
             section.Add(_uccEnableLTBar = AddCheckBox(null, "Enable UCC - LastTarget Bar", _currentProfile.UOClassicCombatLTBar, startX, startY));
             startY += _uccEnableLTBar.Height + 2;
@@ -3955,7 +4202,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _visualResponseManager.Height + 2;
             // ## BEGIN - END ## // VISUALRESPONSEMANAGER
             // ## BEGIN - END ## // LINES
-            SettingsSection section3 = AddSettingsSection(box, "-----LINES (LINES UI)-----");
+            SettingsSection section3 = AddSettingsSection(box, "LINES UI");
             section3.Y = section.Bounds.Bottom + 40;
 
             startY = section.Bounds.Bottom + 40;
@@ -3964,7 +4211,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _uccEnableLines.Height + 2;
             // ## BEGIN - END ## // LINES
             // ## BEGIN - END ## // AUTOLOOT
-            SettingsSection section4 = AddSettingsSection(box, "-----AUTOLOOT (AL UI)-----");
+            SettingsSection section4 = AddSettingsSection(box, "AUTOLOOT UI");
             section4.Y = section3.Bounds.Bottom + 40;
 
             startY = section3.Bounds.Bottom + 40;
@@ -3976,7 +4223,7 @@ namespace ClassicUO.Game.UI.Gumps
             section4.Add(_uccBEnableLootAboveID = AddCheckBox(null, "Enable LootAboveID", _currentProfile.UOClassicCombatAL_EnableLootAboveID, startX, startY));
             startY += _uccBEnableLootAboveID.Height + 2;
 
-            SettingsSection section6 = AddSettingsSection(box, "-----BUFFBAR (COOLDOWN UI)-----");
+            SettingsSection section6 = AddSettingsSection(box, "COOLDOWN UI");
             section6.Y = section4.Bounds.Bottom + 40;
 
             startY = section4.Bounds.Bottom + 40;
@@ -3987,7 +4234,7 @@ namespace ClassicUO.Game.UI.Gumps
             section6.Add(_uccEnableSelf = AddCheckBox(null, "Enable UCC - Self", _currentProfile.UOClassicCombatSelf, startX, startY));
             startY += _uccEnableSelf.Height + 2;
 
-            section6.Add(AddLabel(null, "-----DISABLE / ENABLE BUFFBAR ON CHANGES BELOW-----", startX, startY));
+            section6.Add(AddLabel(null, "DISABLE / ENABLE BUFFBAR ON CHANGES BELOW", startX, startY));
 
             section6.Add(_uccSwing = AddCheckBox(null, "Show Swing Line", _currentProfile.UOClassicCombatBuffbar_SwingEnabled, startX, startY));
             startY += _uccSwing.Height + 2;
@@ -3999,7 +4246,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _uccLocked.Height + 2;
             // ## BEGIN - END ## // BUFFBAR/UCCSETTINGS
             // ## BEGIN - END ## // BUFFBAR/UCCSETTINGS
-            SettingsSection section7 = AddSettingsSection(box, "-----SETTINGS (BUFFBAR AND SELF)-----");
+            SettingsSection section7 = AddSettingsSection(box, "BUFFBAR AND SELF SETTINGS");
             section7.Y = section6.Bounds.Bottom + 40;
 
             startY = section6.Bounds.Bottom + 40;
@@ -4062,7 +4309,7 @@ namespace ClassicUO.Game.UI.Gumps
             _uccDisarmAttemptCooldown.SetText(_currentProfile.UOClassicCombatSelf_DisarmAttemptCooldown.ToString());
             // ## BEGIN - END ## // BUFFBAR/UCCSETTINGS
             //TRESHOLD SETTINGS
-            SettingsSection section10 = AddSettingsSection(box, "-----SETTINGS (TRESHOLDS)-----");
+            SettingsSection section10 = AddSettingsSection(box, " SETTINGS (TRESHOLDS");
             section10.Y = section7.Bounds.Bottom + 40;
 
             startY = section7.Bounds.Bottom + 40;
@@ -4147,7 +4394,7 @@ namespace ClassicUO.Game.UI.Gumps
             _uccRefreshpotStamTreshold.SetText(_currentProfile.UOClassicCombatSelf_RefreshpotStamTreshold.ToString());
 
             //MISC SETTINGS AREA
-            SettingsSection section11 = AddSettingsSection(box, "-----SETTINGS (MISC)-----");
+            SettingsSection section11 = AddSettingsSection(box, "SETTINGS (MISC)");
             section11.Y = section10.Bounds.Bottom + 40;
 
             startY = section10.Bounds.Bottom + 40;
@@ -4253,7 +4500,7 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // SELF
             // ## BEGIN - END ## // TABGRID // PKRION
             //TABGRID SETTINGS AREA
-            SettingsSection section12 = AddSettingsSection(box, "-----TABGRID-----");
+            SettingsSection section12 = AddSettingsSection(box, "TABGRID");
             section12.Y = section11.Bounds.Bottom + 40;
 
             startY = section11.Bounds.Bottom + 40;
@@ -4327,9 +4574,9 @@ namespace ClassicUO.Game.UI.Gumps
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                20,
+                OptionsScrollY,
                 WIDTH - 185,
-                HEIGHT - 80,
+                OptionsScrollHeight,
                 true
             );
 
@@ -4391,7 +4638,7 @@ namespace ClassicUO.Game.UI.Gumps
         private void BuildGridContainer()
         {
             const int PAGE = 8788;
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
 
             SettingsSection gridSection = new SettingsSection("Grid Containers", rightArea.Width);
@@ -4662,7 +4909,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             const int PAGE = 8789;
 
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
 
             int startX = 5;
@@ -4672,7 +4919,7 @@ namespace ClassicUO.Game.UI.Gumps
             box.WantUpdateSize = true;
             rightArea.Add(box);
 
-            SettingsSection section = AddSettingsSection(box, "-----PROFILE MANAGEMENT-----");
+            SettingsSection section = AddSettingsSection(box, "PROFILE MANAGEMENT");
 
             section.Add(AddLabel(null, "Use these options to share your current settings", startX, startY));
             startY += 20;
@@ -4743,7 +4990,7 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // TAZUO
             //ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
             // ## BEGIN - END ## // TAZUO
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
             // ## BEGIN - END ## // TAZUO
 
@@ -4805,6 +5052,27 @@ namespace ClassicUO.Game.UI.Gumps
 
             section.AddRight(AddLabel(null, _langDust.CannonballOrPrevCoinColor, 0, 0), 2);
 
+            section.Add(
+                AddLabel(
+                    null,
+                    "Jewelry (rings, bracelets, etc.) is tiny on the paperdoll. Enable larger icons in those slots?",
+                    startX,
+                    startY
+                )
+            );
+            startY += 36;
+
+            section.Add(
+                _enlargeJewelryPaperdoll = AddCheckBox(
+                    null,
+                    "Yes — enlarge ring, bracelet, earrings, necklace and talisman on paperdoll",
+                    _currentProfile.EnlargeJewelryOnPaperdoll,
+                    startX,
+                    startY
+                )
+            );
+            startY += _enlargeJewelryPaperdoll.Height + 2;
+
             section.Add(AddLabel(null, _langDust.ChangeTreeArtTo, startX, startY));
 
             mode = _currentProfile.TreeType;
@@ -4834,7 +5102,7 @@ namespace ClassicUO.Game.UI.Gumps
             section.AddRight(AddLabel(null, _langDust.StumpOrTileColor, 0, 0), 2);
             // ## BEGIN - END ## // ART / HUE CHANGES
             // ## BEGIN - END ## // TITLE BAR
-            SettingsSection sectionTitleBar = AddSettingsSection(box, "-----TITLE BAR-----");
+            SettingsSection sectionTitleBar = AddSettingsSection(box, "Title Bar");
             sectionTitleBar.Y = section.Bounds.Bottom + 80;
             startY = section.Bounds.Bottom + 80;
 
@@ -4876,7 +5144,7 @@ namespace ClassicUO.Game.UI.Gumps
     
             // ## BEGIN - END ## // TITLE BAR
             // ## BEGIN - END ## // VISUAL HELPERS
-            SettingsSection section2 = AddSettingsSection(box, "-----VISUAL HELPERS-----");
+            SettingsSection section2 = AddSettingsSection(box, "Visual Helpers");
             section2.Y = sectionTitleBar.Bounds.Bottom + 40;
 
             startY = sectionTitleBar.Bounds.Bottom + 40;
@@ -4982,7 +5250,7 @@ namespace ClassicUO.Game.UI.Gumps
             section2.AddRight(AddLabel(null, "Custom color mortalled", 0, 0), 2);
             // ## BEGIN - END ## // VISUAL HELPERS
             // ## BEGIN - END ## // HEALTHBAR
-            SettingsSection section3 = AddSettingsSection(box, "-----HEALTHBAR-----");
+            SettingsSection section3 = AddSettingsSection(box, "Health Bar");
             section3.Y = section2.Bounds.Bottom + 40;
 
             startY = section2.Bounds.Bottom + 40;
@@ -4993,7 +5261,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _highlightHealthBarByState.Height + 2;
             // ## BEGIN - END ## // HEALTHBAR
             // ## BEGIN - END ## // CURSOR
-            SettingsSection section4 = AddSettingsSection(box, "-----CURSOR-----");
+            SettingsSection section4 = AddSettingsSection(box, "Cursor");
             section4.Y = section3.Bounds.Bottom + 40;
 
             startY = section3.Bounds.Bottom + 40;
@@ -5048,7 +5316,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _showTargetRangeIndicator.Height + 2;
             // ## BEGIN - END ## // CURSOR
             // ## BEGIN - END ## // OVERHEAD / UNDERCHAR
-            SettingsSection section5 = AddSettingsSection(box, "-----OVERHEAD / UNDERFEET-----");
+            SettingsSection section5 = AddSettingsSection(box, "Overhead / Underfoot");
             section5.Y = section4.Bounds.Bottom + 40;
             startY = section4.Bounds.Bottom + 40;
 
@@ -5056,7 +5324,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _overheadRange.Height + 2;
             // ## BEGIN - END ## // OVERHEAD / UNDERCHAR
             // ## BEGIN - END ## // OLDHEALTHLINES
-            SettingsSection section6 = AddSettingsSection(box, "-----OLDHEALTHLINES-----");
+            SettingsSection section6 = AddSettingsSection(box, "Old Health Lines");
             section6.Y = section5.Bounds.Bottom + 40;
 
             startY = section5.Bounds.Bottom + 40;
@@ -5074,7 +5342,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _multipleUnderlinesSelfPartyTransparency.Height + 2;
             // ## BEGIN - END ## // OLDHEALTHLINES
             // ## BEGIN - END ## // MISC
-            SettingsSection section7 = AddSettingsSection(box, "-----MISC-----");
+            SettingsSection section7 = AddSettingsSection(box, "Misc");
             section7.Y = section6.Bounds.Bottom + 40;
 
             startY = section6.Bounds.Bottom + 40;
@@ -5168,7 +5436,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _blockEnergyFArtForceAoS.Height + 2;
             // ## BEGIN - END ## // MISC
             // ## BEGIN - END ## // MISC2
-            SettingsSection section8 = AddSettingsSection(box, "-----MISC2-----");
+            SettingsSection section8 = AddSettingsSection(box, "Misc2");
             section8.Y = section7.Bounds.Bottom + 40;
 
             startY = section7.Bounds.Bottom + 40;
@@ -5212,8 +5480,6 @@ namespace ClassicUO.Game.UI.Gumps
             section8.Add(_showDeathOnWorldmap = AddCheckBox(null, "Show death location on world map for 5min:", _currentProfile.ShowDeathOnWorldmap, startX, startY));
             startY += _showDeathOnWorldmap.Height + 2;
 
-            section8.Add(_showMapCloseFriend = AddCheckBox(null, "Show closed friend in World Map:", _currentProfile.ShowMapCloseFriend, startX, startY));
-            startY += _showMapCloseFriend.Height + 2;
             section8.Add(_autoAvoidMobiles = AddCheckBox(null, _langDust.AutoAvoidObstaculesAndMobiles, _currentProfile.AutoAvoidObstacules, startX, startY));
             startY += _autoAvoidMobiles.Height + 2;
             section8.Add(_scaleMonstersEnabled = AddCheckBox(null, "Scale monsters (Ctrl+Shift over monster: +/- to scale)", _currentProfile.ScaleMonstersEnabled, startX, startY));
@@ -5224,7 +5490,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // ## BEGIN - END ## // MISC2
             // ## BEGIN - END ## // STATUSGUMP
-            SettingsSection section10 = AddSettingsSection(box, "-----STATUSGUMP-----");
+            SettingsSection section10 = AddSettingsSection(box, "STATUS GUMP");
             section10.Y = section8.Bounds.Bottom + 40;
 
             startY = 0;
@@ -5233,7 +5499,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _useRazorEnhStatusGump.Height + 2;
             // ## BEGIN - END ## // STATUSGUMP
             // ## BEGIN - END ## // MISC3 SHOWALLLAYERS
-            SettingsSection section11 = AddSettingsSection(box, "-----MISC3-----");
+            SettingsSection section11 = AddSettingsSection(box, "MISC3");
             section11.Y = section10.Bounds.Bottom + 40;
 
             startY = section10.Bounds.Bottom + 40;
@@ -5384,7 +5650,7 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // TAZUO
             //ScrollArea rightArea = new ScrollArea(190, 20, WIDTH - 210, 420, true);
             // ## BEGIN - END ## // TAZUO
-            ScrollArea rightArea = new ScrollArea(165, 20, WIDTH - 185, HEIGHT - 80, true);
+            ScrollArea rightArea = new ScrollArea(165, OptionsScrollY, WIDTH - 185, OptionsScrollHeight, true);
             rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
             // ## BEGIN - END ## // TAZUO
 
@@ -5396,7 +5662,7 @@ namespace ClassicUO.Game.UI.Gumps
             rightArea.Add(box);
 
             // ## BEGIN - END ## // VISUAL HELPERS
-            SettingsSection section = AddSettingsSection(box, "-----FEATURES MACROS-----");
+            SettingsSection section = AddSettingsSection(box, "Features Macros");
 
             section.Add(AddLabel(null, "HighlightTileAtRange (toggle HighlightTileAtRange on / off)", startX, startY));
             // ## BEGIN - END ## // VISUAL HELPERS
@@ -5419,7 +5685,7 @@ namespace ClassicUO.Game.UI.Gumps
             section.Add(AddLabel(null, "ToggleModernCooldownBar (toggle on / off modern cooldown bar)", startX, startY));
             // ## BEGIN - END ## // MODERNCOOLDOWNBAR
             // ## BEGIN - END ## // MACROS
-            SettingsSection section2 = AddSettingsSection(box, "-----SIMPLE MACROS-----");
+            SettingsSection section2 = AddSettingsSection(box, "Simple Macros");
             section2.Y = section.Bounds.Bottom + 40;
 
             section2.Add(AddLabel(null, "LastTargetRC (last target with custom range check)", startX, startY));
@@ -5439,7 +5705,7 @@ namespace ClassicUO.Game.UI.Gumps
             section2.Add(AddLabel(null, "OpenCorpses (opens 0x2006 corpses within 2 tiles)", startX, startY));
             // ## BEGIN - END ## // MACROS
             // ## BEGIN - END ## // ADVMACROS
-            SettingsSection section3 = AddSettingsSection(box, "-----ADVANCED MACROS-----");
+            SettingsSection section3 = AddSettingsSection(box, "Advanced Macros");
             section3.Y = section2.Bounds.Bottom + 40;
             startY = section2.Bounds.Bottom + 40;
             section3.Add(AddLabel(null, "use macro to run advanced scripts ONCE:", startX, startY));
@@ -5683,7 +5949,7 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _pullPartyAllyBarsFinalLocationY.Height + 2;
             // ## BEGIN - END ## // ADVMACROS
             // ## BEGIN - END ## // AUTOMATIONS
-            SettingsSection section4 = AddSettingsSection(box, "-----AUTOMATIONS-----");
+            SettingsSection section4 = AddSettingsSection(box, "Automations");
             section4.Y = section3.Bounds.Bottom + 40;
             startY = section3.Bounds.Bottom + 40;
 
@@ -5693,7 +5959,7 @@ namespace ClassicUO.Game.UI.Gumps
             section4.Add(AddLabel(null, "-aibot or macro aibot (auto bot \n)", startX, startY));
             section4.Add(AddLabel(null, "-engange (auto engage and pathfind to last target)", startX, startY));
 
-            SettingsSection section5 = AddSettingsSection(box, "-----MISC-----");
+            SettingsSection section5 = AddSettingsSection(box, "Misc4");
             section5.Y = section4.Bounds.Bottom + 40;
             startY = section4.Bounds.Bottom + 40;
 
@@ -5797,7 +6063,7 @@ namespace ClassicUO.Game.UI.Gumps
             */
             // ## BEGIN - END ## // OUTLANDS
             // ## BEGIN - END ## // LOBBY
-            SettingsSection section6 = AddSettingsSection(box, "-----LOBBY-----");
+            SettingsSection section6 = AddSettingsSection(box, "Lobby");
             section6.Y = section5.Bounds.Bottom + 40;
             startY = section5.Bounds.Bottom + 40;
 
@@ -6963,6 +7229,7 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.GoldType = _goldType.SelectedIndex;
             _currentProfile.GoldHue = _goldColorPickerBox.Hue;
             _currentProfile.ColorGold = _colorGold.IsChecked;
+            _currentProfile.EnlargeJewelryOnPaperdoll = _enlargeJewelryPaperdoll?.IsChecked ?? false;
             _currentProfile.ColorEnergyBolt = _colorEnergyBolt.IsChecked;
             _currentProfile.EnergyBoltHue = _energyBoltColorPickerBox.Hue;
             _currentProfile.ColorTreeTile = _colorTreeTile.IsChecked;
@@ -7348,7 +7615,6 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.OnCastingGump = _onCastingGump.IsChecked;
             _currentProfile.OnCastingGump_hidden = _onCastingGump_hidden.IsChecked;
             _currentProfile.OnCastingUnderPlayerBar = _onCastingUnderPlayerBar.IsChecked;
-            _currentProfile.ShowMapCloseFriend = _showMapCloseFriend.IsChecked;
             _currentProfile.AutoAvoidObstacules = _autoAvoidMobiles.IsChecked;
             _currentProfile.ScaleMonstersEnabled = _scaleMonstersEnabled.IsChecked;
             // ## BEGIN - END ## // ONCASTINGGUMP
@@ -7612,9 +7878,9 @@ namespace ClassicUO.Game.UI.Gumps
                 new Rectangle
                 (
                     x + 165,
-                    y + 20,
+                    y + OptionsScrollY,
                     WIDTH - 250,
-                    400
+                    Math.Max(120, 400 - OptionsScrollY)
                 ),
                 hueVector
             );
@@ -7629,7 +7895,54 @@ namespace ClassicUO.Game.UI.Gumps
                 hueVector
             );
 
-            return base.Draw(batcher, x, y);
+            bool drawn = base.Draw(batcher, x, y);
+            if (_optionsSearchAppliedTerm.Length >= 2)
+            {
+                Texture2D white = SolidColorTextureCache.GetTexture(Color.White);
+                const int border = 2;
+                const int pad = 1;
+                foreach (Control ch in Children)
+                {
+                    if (ch is not NiceButton nb || ch.Page != 0 || !nb.IsSwitchPage || nb.IsDisposed || !nb.IsVisible)
+                    {
+                        continue;
+                    }
+
+                    if (!_optionsSearchPagesWithHits.Contains(nb.ButtonParameter))
+                    {
+                        continue;
+                    }
+
+                    GetControlPositionInOptionsGump(this, nb, out int tx, out int ty);
+                    int tw = Math.Max(4, nb.Width);
+                    int th = Math.Max(4, nb.Height);
+                    DrawOptionsSearchHighlightBorder(batcher, white, hueVector, x + tx - pad, y + ty - pad, tw + pad * 2, th + pad * 2, border);
+                }
+
+                if (ActivePage > 0)
+                {
+                    for (int i = 0; i < _optionsSearchMatches.Count; i++)
+                    {
+                        Control c = _optionsSearchMatches[i];
+                        if (c == null || c.IsDisposed || !c.IsVisible || OptionsSearchContentPage(c) != ActivePage)
+                        {
+                            continue;
+                        }
+
+                        GetControlPositionInOptionsGump(this, c, out int gx, out int gy);
+                        int w = Math.Max(4, c.Width);
+                        int h = Math.Max(4, c.Height);
+                        if (!OptionsSearchHighlightVisible(c, gx, gy, w, h))
+                        {
+                            continue;
+                        }
+
+                        DrawOptionsSearchHighlightBorder(batcher, white, hueVector, x + gx - pad, y + gy - pad, w + pad * 2, h + pad * 2, border);
+                    }
+                }
+            }
+
+            return drawn;
         }
 
         private InputField AddInputField
@@ -7859,8 +8172,8 @@ namespace ClassicUO.Game.UI.Gumps
                 AcceptMouseInput = true;
                 WantUpdateSize = true;
 
-
-                Label label = new Label(title, true, HUE_FONT, font: FONT);
+                string displayTitle = string.IsNullOrEmpty(title) ? title : title.ToUpperInvariant();
+                Label label = new Label(displayTitle, true, HUE_FONT, font: FONT);
                 label.X = 5;
                 base.Add(label);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -54,6 +54,7 @@ using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using SDL3;
 using System.Threading.Tasks;
 using System.Net.Http;
 
@@ -68,7 +69,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int TEXTBOX_HEIGHT = 25;
         private const int OptionsTabStartY = 10;
         private const int OptionsSearchRowHeight = 26;
-        private const int OptionsSearchToContentGap = 2;
+        private const int OptionsSearchToContentGap = 12;
         private static int OptionsScrollY =>
             OptionsTabStartY + OptionsSearchRowHeight + OptionsSearchToContentGap;
         private static int OptionsScrollHeight => HEIGHT - 60 - OptionsScrollY;
@@ -218,7 +219,9 @@ namespace ClassicUO.Game.UI.Gumps
         // ## BEGIN - END ## // ART / HUE CHANGES
         private Checkbox _colorStealth, _colorEnergyBolt, _colorGold, _colorTreeTile, _colorBlockerTile, _enlargeJewelryPaperdoll;
         private ModernColorPicker.HueDisplay _stealthColorPickerBox, _energyBoltColorPickerBox, _goldColorPickerBox, _treeTileColorPickerBox, _blockerTileColorPickerBox;
-        private Combobox _goldType, _treeType, _blockerType, _stealthNeonType, _energyBoltNeonType, _energyBoltArtType;
+        private Combobox _goldType, _treeType, _blockerType, _stealthNeonType, _energyBoltNeonType, _energyBoltArtType, _moongateHueStyle;
+        private Checkbox _moongateRecolor, _scaleMonstersEnabled;
+        private ModernColorPicker.HueDisplay _moongateCustomHuePicker;
         // ## BEGIN - END ## // ART / HUE CHANGES
         // ## BEGIN - END ## // VISUAL HELPERS
         private Checkbox _highlightTileRange, _highlightTileRangeSpell, _ownAuraByHP, _previewFields;
@@ -245,7 +248,7 @@ namespace ClassicUO.Game.UI.Gumps
         private InputField _SpecialSetLastTargetClilocText, _blockWoSArt, _blockEnergyFArt;
         // ## BEGIN - END ## // MISC
         // ## BEGIN - END ## // MISC2
-        private Checkbox _wireframeView, _hueImpassableView, _transparentHouses, _invisibleHouses, _ignoreCoT, _showDeathOnWorldmap, _drawMobilesWithSurfaceOverhead, _autoAvoidMobiles, _scaleMonstersEnabled, _forceGargoyleWalk;
+        private Checkbox _wireframeView, _hueImpassableView, _transparentHouses, _invisibleHouses, _ignoreCoT, _showDeathOnWorldmap, _drawMobilesWithSurfaceOverhead, _autoAvoidMobiles, _forceGargoyleWalk;
         private HSliderBar _transparentHousesZ, _transparentHousesTransparency, _invisibleHousesZ, _dontRemoveHouseBelowZ;
         // ## BEGIN - END ## // MISC2
         // ## BEGIN - END ## // MACROS
@@ -318,6 +321,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private Checkbox _leftAlignToolTips, _namePlateHealthOnlyWarmode, _enableHealthIndicator, _spellIconDisplayHotkey, _enableAlphaScrollWheel, _useModernShop, _forceCenterAlignMobileTooltips, _openHealthBarForLastAttack;
         private Checkbox _hideJournalBorder, _hideJournalTimestamp, _gridHideBorder, _skillProgressBarOnChange, _uselastCooldownPosition, _closeHPBarWhenAnchored, _enableNearbyItemGump;
+        private HotkeyBox _nearbyItemGumpHotkeyBox;
         private InputField _healthIndicatorPercentage, _healthIndicatorWidth, _tooltipHeaderFormat, _skillProgressBarFormat;
         private ModernColorPicker.HueDisplay _mainWindowHuePicker, _spellIconHotkeyHue, _tooltipBGHue;
         private HSliderBar _spellIconScale, _overheadTextWidth, _gridHightlightLineSize, _maxJournalEntries;
@@ -3909,24 +3913,28 @@ namespace ClassicUO.Game.UI.Gumps
         {
             const int PAGE = 13;
             int top = OptionsScrollY;
-            int topButtonY = top + 52 + 25 + 4;
+            int nameListTop = top + 54;
             int bottomSeparatorY = HEIGHT - 51;
+            const int nameOverheadDividerX = 322;
+            int nameListW = nameOverheadDividerX - 165;
 
             ScrollArea rightArea = new ScrollArea
             (
                 165,
-                topButtonY,
-                150,
-                bottomSeparatorY - topButtonY,
+                nameListTop,
+                nameListW,
+                bottomSeparatorY - nameListTop,
                 true
             );
+            rightArea.ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways;
+            rightArea.UpdateScrollbarPosition();
 
             Add
             (
                 new Line
                 (
                     165,
-                    top + 52 + 25 + 2,
+                    nameListTop - 2,
                     WIDTH - 165,
                     1,
                     Color.Gray.PackedValue
@@ -3938,7 +3946,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new Line
                 (
-                    165 + 150,
+                    nameOverheadDividerX,
                     top + 21,
                     1,
                     bottomSeparatorY - top - 21,
@@ -4022,8 +4030,8 @@ namespace ClassicUO.Game.UI.Gumps
                         NameOverHeadManager.AddOption(option);
                         _nameOverheadControl = new NameOverheadAssignControl(option)
                         {
-                            X = 325,
-                            Y = 20
+                            X = nameOverheadDividerX + 10,
+                            Y = OptionsScrollY + 10
                         };
                         Add(_nameOverheadControl, PAGE);
                         nb.MouseUp += (sss, eee) =>
@@ -4031,8 +4039,8 @@ namespace ClassicUO.Game.UI.Gumps
                             _nameOverheadControl?.Dispose();
                             _nameOverheadControl = new NameOverheadAssignControl(option)
                             {
-                                X = 325,
-                                Y = 20
+                                X = nameOverheadDividerX + 10,
+                                Y = OptionsScrollY + 10
                             };
                             Add(_nameOverheadControl, PAGE);
                         };
@@ -4106,8 +4114,8 @@ namespace ClassicUO.Game.UI.Gumps
                     _nameOverheadControl?.Dispose();
                     _nameOverheadControl = new NameOverheadAssignControl(option)
                     {
-                        X = 325,
-                        Y = 20
+                        X = nameOverheadDividerX + 10,
+                        Y = OptionsScrollY + 10
                     };
                     Add(_nameOverheadControl, PAGE);
                 };
@@ -5055,7 +5063,7 @@ namespace ClassicUO.Game.UI.Gumps
             section.Add(
                 AddLabel(
                     null,
-                    "Jewelry (rings, bracelets, etc.) is tiny on the paperdoll. Enable larger icons in those slots?",
+                    "Ring and bracelet art is small on paperdoll and in bags (grid). Scale them up when enabled below.",
                     startX,
                     startY
                 )
@@ -5065,7 +5073,7 @@ namespace ClassicUO.Game.UI.Gumps
             section.Add(
                 _enlargeJewelryPaperdoll = AddCheckBox(
                     null,
-                    "Yes — enlarge ring, bracelet, earrings, necklace and talisman on paperdoll",
+                    "Enlarge ring and bracelet on paperdoll and in grid containers",
                     _currentProfile.EnlargeJewelryOnPaperdoll,
                     startX,
                     startY
@@ -5100,6 +5108,30 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _blockerTileColorPickerBox.Height + 2;
 
             section.AddRight(AddLabel(null, _langDust.StumpOrTileColor, 0, 0), 2);
+
+            section.Add(_moongateRecolor = AddCheckBox(null, "Recolor moongates (graphic 0xF6C)", _currentProfile.MoongateRecolorEnabled, startX, startY));
+            startY += _moongateRecolor.Height + 2;
+
+            int moongateMode = _currentProfile.MoongateHueStyle - 1;
+
+            if (moongateMode < 0)
+            {
+                moongateMode = 0;
+            }
+            else if (moongateMode > 4)
+            {
+                moongateMode = 4;
+            }
+
+            section.Add(_moongateHueStyle = AddCombobox(null, new[] { _langDust.White, _langDust.Pink, _langDust.Ice, _langDust.Fire, _langDust.Custom }, moongateMode, startX, startY, 100));
+            startY += _moongateHueStyle.Height + 2;
+
+            section.Add(_moongateCustomHuePicker = AddHueDisplay(null, startX, startY, _currentProfile.MoongateCustomHue, ""));
+            startY += _moongateCustomHuePicker.Height + 2;
+            section.AddRight(AddLabel(null, "Moongate custom hue", 0, 0), 2);
+
+            section.Add(_scaleMonstersEnabled = AddCheckBox(null, "Scale monsters (Ctrl+Shift over monster: +/- to scale)", _currentProfile.ScaleMonstersEnabled, startX, startY));
+            startY += _scaleMonstersEnabled.Height + 2;
             // ## BEGIN - END ## // ART / HUE CHANGES
             // ## BEGIN - END ## // TITLE BAR
             SettingsSection sectionTitleBar = AddSettingsSection(box, "Title Bar");
@@ -5482,8 +5514,6 @@ namespace ClassicUO.Game.UI.Gumps
 
             section8.Add(_autoAvoidMobiles = AddCheckBox(null, _langDust.AutoAvoidObstaculesAndMobiles, _currentProfile.AutoAvoidObstacules, startX, startY));
             startY += _autoAvoidMobiles.Height + 2;
-            section8.Add(_scaleMonstersEnabled = AddCheckBox(null, "Scale monsters (Ctrl+Shift over monster: +/- to scale)", _currentProfile.ScaleMonstersEnabled, startX, startY));
-            startY += _scaleMonstersEnabled.Height + 2;
 
             section8.Add(_forceGargoyleWalk = AddCheckBox(null, "Force gargoyle to walk instead of fly", _currentProfile.ForceGargoyleWalk, startX, startY));
             startY += _forceGargoyleWalk.Height + 2;
@@ -5641,6 +5671,18 @@ namespace ClassicUO.Game.UI.Gumps
             sectionMiscTaz.Add(autoLootBtn);
             sectionMiscTaz.Add(_enableNearbyItemGump = AddCheckBox(null, "", _currentProfile.EnableNearbyItemGump, 0, 0));
             sectionMiscTaz.AddRight(AddLabel(null, _langDust.ShowUseLootModalOnCtrl, 0, 0));
+            sectionMiscTaz.Add(AddLabel(null, _langDust.NearbyItemModalHotkeyHint, 0, 0));
+            _nearbyItemGumpHotkeyBox = new HotkeyBox();
+            int nk = _currentProfile.NearbyItemGumpHotkeyKey;
+            uint nm = _currentProfile.NearbyItemGumpHotkeyMod;
+            if (nk == 0)
+            {
+                nk = (int)SDL.SDL_Keycode.SDLK_LCTRL;
+                nm = 0;
+            }
+
+            _nearbyItemGumpHotkeyBox.SetKey((SDL.SDL_Keycode)nk, (SDL.SDL_Keymod)nm);
+            sectionMiscTaz.Add(_nearbyItemGumpHotkeyBox);
 
             Add(rightArea, PAGE);
         }
@@ -6459,6 +6501,17 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.CloseHealthBarIfAnchored = _closeHPBarWhenAnchored.IsChecked;
             _currentProfile.EnableNearbyItemGump = _enableNearbyItemGump.IsChecked;
+            if (_nearbyItemGumpHotkeyBox != null && _nearbyItemGumpHotkeyBox.Key != SDL.SDL_Keycode.SDLK_UNKNOWN)
+            {
+                _currentProfile.NearbyItemGumpHotkeyKey = (int)_nearbyItemGumpHotkeyBox.Key;
+                _currentProfile.NearbyItemGumpHotkeyMod = (uint)_nearbyItemGumpHotkeyBox.Mod;
+            }
+            else if (_nearbyItemGumpHotkeyBox != null)
+            {
+                _currentProfile.NearbyItemGumpHotkeyKey = (int)SDL.SDL_Keycode.SDLK_LCTRL;
+                _currentProfile.NearbyItemGumpHotkeyMod = 0;
+            }
+
             _currentProfile.UseLastMovedCooldownPosition = _uselastCooldownPosition.IsChecked;
 
             _currentProfile.PlayerConstantAlpha = _regularPlayerAlpha.Value;
@@ -7248,6 +7301,21 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 _currentProfile.TreeType = _treeType.SelectedIndex;
             }
+
+            _currentProfile.MoongateRecolorEnabled = _moongateRecolor.IsChecked;
+            _currentProfile.MoongateHueStyle = _moongateHueStyle.SelectedIndex + 1;
+
+            if (_currentProfile.MoongateHueStyle < 1)
+            {
+                _currentProfile.MoongateHueStyle = 1;
+            }
+            else if (_currentProfile.MoongateHueStyle > 5)
+            {
+                _currentProfile.MoongateHueStyle = 5;
+            }
+
+            _currentProfile.MoongateCustomHue = _moongateCustomHuePicker.Hue;
+            _currentProfile.ScaleMonstersEnabled = _scaleMonstersEnabled.IsChecked;
             // ## BEGIN - END ## // ART / HUE CHANGES
             // ## BEGIN - END ## // VISUAL HELPERS
             _currentProfile.HighlightTileAtRange = _highlightTileRange.IsChecked;
@@ -7616,7 +7684,6 @@ namespace ClassicUO.Game.UI.Gumps
             _currentProfile.OnCastingGump_hidden = _onCastingGump_hidden.IsChecked;
             _currentProfile.OnCastingUnderPlayerBar = _onCastingUnderPlayerBar.IsChecked;
             _currentProfile.AutoAvoidObstacules = _autoAvoidMobiles.IsChecked;
-            _currentProfile.ScaleMonstersEnabled = _scaleMonstersEnabled.IsChecked;
             // ## BEGIN - END ## // ONCASTINGGUMP
 
             RefreshBandageAndOnCastingGumps();
@@ -8166,14 +8233,14 @@ namespace ClassicUO.Game.UI.Gumps
             private readonly DataBox _databox;
             private int _indent;
 
-            public SettingsSection(string title, int width)
+            public SettingsSection(string title, int width, ushort titleHue = 0xFFFF)
             {
                 CanMove = true;
                 AcceptMouseInput = true;
                 WantUpdateSize = true;
 
                 string displayTitle = string.IsNullOrEmpty(title) ? title : title.ToUpperInvariant();
-                Label label = new Label(displayTitle, true, HUE_FONT, font: FONT);
+                Label label = new Label(displayTitle, true, titleHue, font: FONT);
                 label.X = 5;
                 base.Add(label);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -245,9 +245,6 @@ namespace ClassicUO.Game.UI.Gumps
         // ## BEGIN - END ## // MACROS
         private HSliderBar _lastTargetRange;
         // ## BEGIN - END ## // MACROS
-        // ## BEGIN - END ## // NAMEOVERHEAD
-        private Checkbox _showHPLineInNOH;
-        // ## BEGIN - END ## // NAMEOVERHEAD
         // ## BEGIN - END ## // UI/GUMPS
         private Checkbox _bandageGump, _bandageUpDownToggle, _uccEnableLTBar;
         private InputField _bandageGumpOffsetX, _bandageGumpOffsetY;
@@ -5226,21 +5223,11 @@ namespace ClassicUO.Game.UI.Gumps
             startY += _forceGargoyleWalk.Height + 2;
 
             // ## BEGIN - END ## // MISC2
-            // ## BEGIN - END ## // NAMEOVERHEAD
-            SettingsSection section9 = AddSettingsSection(box, "-----NAMEOVERHEAD-----");
-            section9.Y = section8.Bounds.Bottom + 40;
-
-            startY = section8.Bounds.Bottom + 40;
-
-            section9.Add(_showHPLineInNOH = AddCheckBox(null, "Show HPLine in NameOverheadGump:", _currentProfile.ShowHPLineInNOH, startX, startY));
-            startY += _showHPLineInNOH.Height + 2;
-
-            // ## BEGIN - END ## // NAMEOVERHEAD
             // ## BEGIN - END ## // STATUSGUMP
             SettingsSection section10 = AddSettingsSection(box, "-----STATUSGUMP-----");
-            section10.Y = section9.Bounds.Bottom + 40;
+            section10.Y = section8.Bounds.Bottom + 40;
 
-            startY = section9.Bounds.Bottom + 40;
+            startY = 0;
 
             section10.Add(_useRazorEnhStatusGump = AddCheckBox(null, "Use Razor Enhanced status gump:", _currentProfile.UseRazorEnhStatusGump, startX, startY));
             startY += _useRazorEnhStatusGump.Height + 2;
@@ -7136,9 +7123,6 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // MACROS
             _currentProfile.LastTargetRange = _lastTargetRange.Value;
             // ## BEGIN - END ## // MACROS
-            // ## BEGIN - END ## // NAMEOVERHEAD
-            _currentProfile.ShowHPLineInNOH = _showHPLineInNOH.IsChecked;
-            // ## BEGIN - END ## // NAMEOVERHEAD
             // ## BEGIN - END ## // UI/GUMPS
             _currentProfile.BandageGump = _bandageGump.IsChecked;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -853,13 +853,9 @@ namespace ClassicUO.Game.UI.Gumps
             private Control bg, border;
             private double forcedScale = 1f;
 
-            private static bool IsJewelryPaperdollLayer(Layer layer)
+            private static bool IsRingOrBraceletSlot(Layer layer)
             {
-                return layer == Layer.Ring
-                    || layer == Layer.Bracelet
-                    || layer == Layer.Earrings
-                    || layer == Layer.Necklace
-                    || layer == Layer.Talisman;
+                return layer == Layer.Ring || layer == Layer.Bracelet;
             }
 
             public EquipmentSlot(
@@ -920,12 +916,17 @@ namespace ClassicUO.Game.UI.Gumps
                 if (mobile != null)
                 {
                     Item it_at_layer = mobile.FindItemByLayer(Layer);
-                    bool jewelryLayer = IsJewelryPaperdollLayer(Layer);
+                    bool ringOrBracelet = IsRingOrBraceletSlot(Layer);
                     bool wantLargeJewelry =
-                        jewelryLayer
+                        ringOrBracelet
                         && ProfileManager.CurrentProfile?.EnlargeJewelryOnPaperdoll == true;
 
-                    if (_itemGump != null && jewelryLayer && wantLargeJewelry != _jewelrySlotBuiltLarge)
+                    bool braceletLarge =
+                        wantLargeJewelry && Layer == Layer.Bracelet;
+
+                    if (_itemGump != null
+                        && ringOrBracelet
+                        && (wantLargeJewelry != _jewelrySlotBuiltLarge || _itemGump.BraceletLarge != braceletLarge))
                     {
                         _itemGump.Dispose();
                         _itemGump = null;
@@ -949,10 +950,21 @@ namespace ClassicUO.Game.UI.Gumps
                             int fh = 18;
                             int fx = 0;
                             int fy = 0;
+                            bool enlargeDraw = false;
                             if (wantLargeJewelry)
                             {
-                                fw = fh = 36;
-                                fx = fy = -9;
+                                if (Layer == Layer.Bracelet)
+                                {
+                                    fw = fh = 20;
+                                    fx = fy = -1;
+                                }
+                                else
+                                {
+                                    fw = fh = 22;
+                                    fx = fy = -2;
+                                }
+
+                                enlargeDraw = true;
                                 _jewelrySlotBuiltLarge = true;
                             }
                             else
@@ -961,7 +973,7 @@ namespace ClassicUO.Game.UI.Gumps
                             }
 
                             Add(
-                                _itemGump = new ItemGumpFixed(item, fw, fh)
+                                _itemGump = new ItemGumpFixed(item, fw, fh, enlargeDraw, braceletLarge)
                                 {
                                     X = fx,
                                     Y = fy,
@@ -1007,10 +1019,14 @@ namespace ClassicUO.Game.UI.Gumps
                 private Point originalSize;
                 private Point point;
                 private readonly Rectangle graphicSize;
+                private readonly bool _scaleUpSmallArt;
+                public bool BraceletLarge { get; }
 
-                public ItemGumpFixed(Item item, int w, int h)
+                public ItemGumpFixed(Item item, int w, int h, bool scaleUpSmallArt = false, bool braceletLarge = false)
                     : base(item.Serial, item.DisplayedGraphic, item.Hue, item.X, item.Y)
                 {
+                    _scaleUpSmallArt = scaleUpSmallArt;
+                    BraceletLarge = braceletLarge;
                     Width = w;
                     Height = h;
                     WantUpdateSize = false;
@@ -1037,19 +1053,22 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     base.ScaleWidthAndHeight(scale);
 
-                    originalSize.X = Width;
-                    originalSize.Y = Height;
-
-                    if (graphicSize.Width < Width)
+                    if (!_scaleUpSmallArt)
                     {
-                        originalSize.X = graphicSize.Width;
-                        point.X = (Width >> 1) - (originalSize.X >> 1);
-                    }
+                        originalSize.X = Width;
+                        originalSize.Y = Height;
 
-                    if (graphicSize.Height < Height)
-                    {
-                        originalSize.Y = graphicSize.Height;
-                        point.Y = (Height >> 1) - (originalSize.Y >> 1);
+                        if (graphicSize.Width < Width)
+                        {
+                            originalSize.X = graphicSize.Width;
+                            point.X = (Width >> 1) - (originalSize.X >> 1);
+                        }
+
+                        if (graphicSize.Height < Height)
+                        {
+                            originalSize.Y = graphicSize.Height;
+                            point.Y = (Height >> 1) - (originalSize.Y >> 1);
+                        }
                     }
 
                     return this;
@@ -1077,9 +1096,40 @@ namespace ClassicUO.Game.UI.Gumps
                     );
 
                     ref readonly var artInfo = ref Client.Game.Arts.GetArt(item.DisplayedGraphic);
-                    
 
-                    if (artInfo.Texture != null)
+                    if (artInfo.Texture == null)
+                    {
+                        return false;
+                    }
+
+                    int srcW = graphicSize.Width;
+                    int srcH = graphicSize.Height;
+                    if (srcW < 1 || srcH < 1)
+                    {
+                        return false;
+                    }
+
+                    if (_scaleUpSmallArt)
+                    {
+                        float mult = BraceletLarge ? 1.55f : 1.8f;
+                        int lo = BraceletLarge ? 8 : 10;
+                        int dw = Math.Min(Width, Math.Max(lo, (int)Math.Ceiling(srcW * mult)));
+                        int dh = Math.Min(Height, Math.Max(lo, (int)Math.Ceiling(srcH * mult)));
+                        int px = x + (Width - dw) / 2;
+                        int py = y + (Height - dh) / 2;
+                        batcher.Draw(
+                            artInfo.Texture,
+                            new Rectangle(px, py, dw, dh),
+                            new Rectangle(
+                                artInfo.UV.X + graphicSize.X,
+                                artInfo.UV.Y + graphicSize.Y,
+                                srcW,
+                                srcH
+                            ),
+                            hueVector
+                        );
+                    }
+                    else
                     {
                         batcher.Draw(
                             artInfo.Texture,
@@ -1097,11 +1147,9 @@ namespace ClassicUO.Game.UI.Gumps
                             ),
                             hueVector
                         );
-
-                        return true;
                     }
 
-                    return false;
+                    return true;
                 }
 
                 public override bool Contains(int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -848,9 +848,19 @@ namespace ClassicUO.Game.UI.Gumps
             private ItemGumpFixed _itemGump;
             private Label _durabilityExclamation;
             private readonly PaperDollGump _paperDollGump;
+            private bool _jewelrySlotBuiltLarge;
 
             private Control bg, border;
             private double forcedScale = 1f;
+
+            private static bool IsJewelryPaperdollLayer(Layer layer)
+            {
+                return layer == Layer.Ring
+                    || layer == Layer.Bracelet
+                    || layer == Layer.Earrings
+                    || layer == Layer.Necklace
+                    || layer == Layer.Talisman;
+            }
 
             public EquipmentSlot(
                 uint serial,
@@ -910,6 +920,16 @@ namespace ClassicUO.Game.UI.Gumps
                 if (mobile != null)
                 {
                     Item it_at_layer = mobile.FindItemByLayer(Layer);
+                    bool jewelryLayer = IsJewelryPaperdollLayer(Layer);
+                    bool wantLargeJewelry =
+                        jewelryLayer
+                        && ProfileManager.CurrentProfile?.EnlargeJewelryOnPaperdoll == true;
+
+                    if (_itemGump != null && jewelryLayer && wantLargeJewelry != _jewelrySlotBuiltLarge)
+                    {
+                        _itemGump.Dispose();
+                        _itemGump = null;
+                    }
 
                     if ((it_at_layer != null && _itemGump != null && _itemGump.Graphic != it_at_layer.DisplayedGraphic) || _itemGump == null)
                     {
@@ -925,13 +945,28 @@ namespace ClassicUO.Game.UI.Gumps
                         {
                             LocalSerial = it_at_layer.Serial;
 
+                            int fw = 18;
+                            int fh = 18;
+                            int fx = 0;
+                            int fy = 0;
+                            if (wantLargeJewelry)
+                            {
+                                fw = fh = 36;
+                                fx = fy = -9;
+                                _jewelrySlotBuiltLarge = true;
+                            }
+                            else
+                            {
+                                _jewelrySlotBuiltLarge = false;
+                            }
+
                             Add(
-                                _itemGump = new ItemGumpFixed(item, 18, 18)
+                                _itemGump = new ItemGumpFixed(item, fw, fh)
                                 {
-                                    X = 0,
-                                    Y = 0,
-                                    Width = 18,
-                                    Height = 18,
+                                    X = fx,
+                                    Y = fy,
+                                    Width = fw,
+                                    Height = fh,
                                     HighlightOnMouseOver = false,
                                     CanPickUp =
                                         World.InGame

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -437,6 +437,16 @@ namespace ClassicUO.Game.UI.Gumps
                     GameActions.Say("[guildtracking", ProfileManager.CurrentProfile?.SpeechHue ?? 0);
                     World.WMapManager.SetEnable(_showPartyMembers || _showGuildMembers);
                     SaveSettings();
+                    UIManager.Add(
+                        new MessageBoxGump(
+                            380,
+                            150,
+                            _showGuildMembers
+                                ? "Guild tracking is ENABLED.\nThe world map will show guild members when the server sends their positions."
+                                : "Guild tracking is DISABLED.\nGuild members will no longer be updated on the world map.",
+                            null
+                        )
+                    );
                 },
                 true,
                 _showGuildMembers

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -444,7 +444,10 @@ namespace ClassicUO.Game.UI.Gumps
                             _showGuildMembers
                                 ? "Guild tracking is ENABLED.\nThe world map will show guild members when the server sends their positions."
                                 : "Guild tracking is DISABLED.\nGuild members will no longer be updated on the world map.",
-                            null
+                            null,
+                            false,
+                            MessageButtonType.OK,
+                            1
                         )
                     );
                 },

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -126,6 +126,7 @@ namespace ClassicUO.Game.UI.Gumps
         private bool _showMobiles = true;
         private bool _showMultis = true;
         private bool _showPartyMembers = true;
+        private bool _showGuildMembers;
         private bool _showPlayerBar = true;
         private bool _showPlayerName = true;
         private int _zoomIndex = 4;
@@ -235,8 +236,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             _flipMap = ProfileManager.CurrentProfile.WorldMapFlipMap;
             _showPartyMembers = ProfileManager.CurrentProfile.WorldMapShowParty;
+            _showGuildMembers = ProfileManager.CurrentProfile.WorldMapShowGuild;
 
-            World.WMapManager.SetEnable(_showPartyMembers);
+            World.WMapManager.SetEnable(_showPartyMembers || _showGuildMembers);
 
             _zoomIndex = ProfileManager.CurrentProfile.WorldMapZoomIndex;
 
@@ -279,6 +281,7 @@ namespace ClassicUO.Game.UI.Gumps
             ProfileManager.CurrentProfile.WorldMapTopMost = TopMost;
             ProfileManager.CurrentProfile.WorldMapFreeView = FreeView;
             ProfileManager.CurrentProfile.WorldMapShowParty = _showPartyMembers;
+            ProfileManager.CurrentProfile.WorldMapShowGuild = _showGuildMembers;
 
             ProfileManager.CurrentProfile.WorldMapZoomIndex = _zoomIndex;
 
@@ -419,12 +422,24 @@ namespace ClassicUO.Game.UI.Gumps
                 () =>
                 {
                     _showPartyMembers = !_showPartyMembers;
-
-                    World.WMapManager.SetEnable(_showPartyMembers);
+                    World.WMapManager.SetEnable(_showPartyMembers || _showGuildMembers);
                     SaveSettings();
                 },
                 true,
                 _showPartyMembers
+            );
+            _options["show_guild_members"] = new ContextMenuItemEntry
+            (
+                "Show Guild",
+                () =>
+                {
+                    _showGuildMembers = !_showGuildMembers;
+                    GameActions.Say("[guildtracking", ProfileManager.CurrentProfile?.SpeechHue ?? 0);
+                    World.WMapManager.SetEnable(_showPartyMembers || _showGuildMembers);
+                    SaveSettings();
+                },
+                true,
+                _showGuildMembers
             );
             _options["show_corpse"] = new ContextMenuItemEntry("Show my Corpse", () => { _showCorpse = !_showCorpse; SaveSettings(); }, true, _showCorpse);
 
@@ -651,6 +666,7 @@ namespace ClassicUO.Game.UI.Gumps
             ContextMenu.Add(_options["free_view"]);
             ContextMenu.Add("", null);
             ContextMenu.Add(_options["show_party_members"]);
+            ContextMenu.Add(_options["show_guild_members"]);
             ContextMenu.Add(_options["show_corpse"]);
             ContextMenu.Add(_options["show_mobiles"]);
             ContextMenu.Add(_options["show_multis"]);
@@ -2526,7 +2542,7 @@ namespace ClassicUO.Game.UI.Gumps
                         {
                             WMapEntity wme = World.WMapManager.GetEntity(mob.Serial);
 
-                            if (wme != null && wme.IsGuild)
+                            if (_showGuildMembers && wme != null && wme.IsGuild)
                             {
                                 DrawWMEntity
                                 (
@@ -2544,11 +2560,13 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            foreach (WMapEntity wme in World.WMapManager.Entities.Values)
+            if (_showGuildMembers)
             {
-                if (wme.IsGuild && !World.Party.Contains(wme.Serial))
+                foreach (WMapEntity wme in World.WMapManager.Entities.Values)
                 {
-                    DrawWMEntity
+                    if (wme.IsGuild && !World.Party.Contains(wme.Serial))
+                    {
+                        DrawWMEntity
                     (
                         batcher,
                         wme,
@@ -2558,6 +2576,7 @@ namespace ClassicUO.Game.UI.Gumps
                         halfHeight,
                         Zoom
                     );
+                    }
                 }
             }
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -313,7 +313,7 @@ namespace ClassicUO.Game
                     else
                     {
                         WMapEntity wme = WMapManager.GetEntity(mob.Serial);
-                        if (mob.NotorietyFlag == NotorietyFlag.Ally || wme != null && wme.IsGuild && ProfileManager.CurrentProfile.ShowMapCloseFriend)
+                        if (mob.NotorietyFlag == NotorietyFlag.Ally || wme != null && wme.IsGuild)
                         {
                             WMapManager.AddOrUpdate
                             (

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -6719,10 +6719,7 @@ namespace ClassicUO.Network
                 World.Player.Flags = flags;
                 World.Player.Walker.DenyWalk(0xFF, -1, -1, -1);
 
-                bool isFrozen = (flags & Flags.Frozen) == Flags.Frozen;
-                World.Player.IsParalyzed = isFrozen;
-
-               GameScene gs = Client.Game.GetScene<GameScene>();
+                GameScene gs = Client.Game.GetScene<GameScene>();
 
                 if (gs != null)
                 {
@@ -6755,6 +6752,13 @@ namespace ClassicUO.Network
                 World.Player.CloseRangedGumps();
                 World.Player.SetInWorldTile(x, y, z);
                 World.Player.UpdateAbilities();
+                // ## BEGIN - END ## // ONCASTINGGUMP
+                if (ProfileManager.CurrentProfile.OnCastingGump) {
+                    GameActions.iscasting = false;
+                    World.Player.OnCasting?.Stop();
+                }
+                // ## BEGIN - END ## // ONCASTINGGUMP
+
             }
         }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -65,6 +65,9 @@ namespace ClassicUO.Network
         public delegate void OnPacketBufferReader(ref StackDataReader p);
 
         private static uint _requestedGridLoot;
+        private static uint _lastStatusSerial;
+        private static long _lastStatusTicks;
+        private const int STATUS_REQUEST_DEBOUNCE_MS = 120;
 
         private static readonly TextFileParser _parser = new TextFileParser(
             string.Empty,
@@ -3691,9 +3694,27 @@ namespace ClassicUO.Network
             GameActions.SendCloseStatus(TargetManager.LastAttack);
             
             TargetManager.LastAttack = serial;
-    
-            GameActions.RequestMobileStatus(serial);
+
+            RequestMobileStatusDebounced(serial);
             
+        }
+
+        private static void RequestMobileStatusDebounced(uint serial)
+        {
+            if (!SerialHelper.IsValid(serial))
+            {
+                return;
+            }
+
+            long now = Time.Ticks;
+            if (_lastStatusSerial == serial && now - _lastStatusTicks < STATUS_REQUEST_DEBOUNCE_MS)
+            {
+                return;
+            }
+
+            _lastStatusSerial = serial;
+            _lastStatusTicks = now;
+            GameActions.RequestMobileStatus(serial);
         }
 
         private static void TextEntryDialog(ref StackDataReader p)
@@ -6657,7 +6678,7 @@ namespace ClassicUO.Network
                     // This is actually a way to get all Hp from all new mobiles.
                     // Real UO client does it only when LastAttack == serial.
                     // We force to close suddenly.
-                    GameActions.RequestMobileStatus(serial);
+                    RequestMobileStatusDebounced(serial);
 
                     //if (TargetManager.LastAttack != serial)
                     //{


### PR DESCRIPTION
- Fixed an issue with OnCasting where the character could become stuck after casting Recall.
- Fixed an issue where the character could become stuck while climbing stairs.
- Improved NameplateOverheadGump: it is now possible to remove the background and health bars, leaving only the character name visible.
- Standardized UI titles, converting them all to uppercase for consistency.
- Fixed Target Hue by Notoriety when Highlight Last Target was disabled.
- Added a Show Guild option to the World Map.
- Improved Nearly Item Gump layout customization, including a new input to assign a hotkey.
- Added a search feature in the Options, allowing items and settings to be found more easily.