### PR TITLE
fix: resolve freeze/lag issues + bump version to 3.0.11

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,23 +27,24 @@ jobs:
       COMMIT_SHA:  ${{ github.sha }}
 
     strategy:
+      max-parallel: 1
       matrix:
         include:
-          - os: windows-latest
-            target: win-x64
-            tfm: net10.0
-            bootTfm: net472
-            bootOutputType: WinExe
-          - os: ubuntu-22.04
-            target: linux-x64
-            tfm: net10.0
-            bootTfm: net472
-            bootOutputType: Exe
           - os: macos-14
             target: osx-x64
             tfm: net10.0
             bootTfm: net472
             bootOutputType: Exe
+          - os: ubuntu-22.04
+            target: linux-x64
+            tfm: net10.0
+            bootTfm: net472
+            bootOutputType: Exe
+          - os: windows-latest
+            target: win-x64
+            tfm: net10.0
+            bootTfm: net472
+            bootOutputType: WinExe
 
     steps:
       - uses: actions/checkout@v4

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AssemblyName>cuo</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>3.0.10</AssemblyVersion>
-    <FileVersion>3.0.10</FileVersion>
+    <AssemblyVersion>3.0.11</AssemblyVersion>
+    <FileVersion>3.0.11</FileVersion>
     <Copyright>Dust765</Copyright>
     <StartupObject></StartupObject>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -167,7 +167,7 @@ namespace ClassicUO.Configuration
         public int FieldsType { get; set; } // 0 = normal, 1 = static, 2 = tile
         public bool NoColorObjectsOutOfRange { get; set; }
         public bool UseCircleOfTransparency { get; set; }
-        public int CircleOfTransparencyRadius { get; set; } = Constants.MAX_CIRCLE_OF_TRANSPARENCY_RADIUS / 2;
+        public int CircleOfTransparencyRadius { get; set; } = Constants.MAX_CIRCLE_OF_TRANSPARENCY_RADIUS /2;
         public int CircleOfTransparencyType { get; set; } // 0 = normal, 1 = like original client
         public int VendorGumpHeight { get; set; } = 60;   //original vendor gump size
         public float DefaultScale { get; set; } = 1.0f;
@@ -225,6 +225,8 @@ namespace ClassicUO.Configuration
         public bool ActivateChatAfterEnter { get; set; }
         public bool ActivateChatAdditionalButtons { get; set; } = true;
         public bool ActivateChatShiftEnterSupport { get; set; } = true;
+        public bool ChatInputAutoLineBreak { get; set; } = true;
+        public int ChatInputMaxCharsPerLine { get; set; } = 100;
         public bool UseObjectsFading { get; set; } = true;
         public bool HoldDownKeyAltToCloseAnchored { get; set; } = true;
         public bool CloseAllAnchoredGumpsInGroupWithRightClick { get; set; } = false;
@@ -521,6 +523,8 @@ namespace ClassicUO.Configuration
         public int TransparentHousesTransparency { get; set; }
         public bool InvisibleHousesEnabled { get; set; } = false;
         public int InvisibleHousesZ { get; set; }
+        public bool HideInvulnerableMannequinNameplates { get; set; }
+        public bool HideInvulnerableMannequinsOnInvisibleHouses { get; set; }
         public int DontRemoveHouseBelowZ { get; set; } = 6;
         public bool DrawMobilesWithSurfaceOverhead { get; set; } = false;
         public bool IgnoreCoTEnabled { get; set; } = false;

--- a/src/ClassicUO.Client/Dust765/Dust765/CombatCollection.cs
+++ b/src/ClassicUO.Client/Dust765/Dust765/CombatCollection.cs
@@ -1414,26 +1414,32 @@ namespace ClassicUO.Dust765.Dust765
         //NETWORK\PACKETHANDLERS.CS
         public static void SpellCastFromCliloc(string text)
         {
-            if (SpellDefinition.WordToTargettype.TryGetValue(text, out SpellDefinition spell))
+            SpellDefinition spell = null;
+
+            if (SpellDefinition.WordToTargettype.TryGetValue(text, out SpellDefinition direct))
             {
+                spell = direct;
                 GameActions.LastSpellIndexCursor = spell.ID;
             }
             else
             {
-                //THIS IS INCASE RAZOR OR ANOTHER ASSISTANT REWRITES THE STRING
-
                 foreach (var key in SpellDefinition.WordToTargettype.Keys)
                 {
-                    if (text.Contains(key)) //SPELL FOUND
+                    if (text.Contains(key))
                     {
-                        GameActions.LastSpellIndexCursor = SpellDefinition.WordToTargettype[key].ID;
-
-                        //break; //DONT BREAK LOOP BECAUSE OF IN NOX / IN NOX GRAV
+                        spell = SpellDefinition.WordToTargettype[key];
+                        GameActions.LastSpellIndexCursor = spell.ID;
                     }
                 }
             }
+
             // ## BEGIN - END ## // ONCASTINGGUMP
-            if (ProfileManager.CurrentProfile.OnCastingGump && World.Player.OnCasting != null)
+            if (
+                spell != null
+                && ProfileManager.CurrentProfile != null
+                && ProfileManager.CurrentProfile.OnCastingGump
+                && World.Player?.OnCasting != null
+            )
             {
                 GameActions.LastSpellIndex = spell.ID;
                 // ## BEGIN - END ## // VISUAL HELPERS
@@ -1441,7 +1447,9 @@ namespace ClassicUO.Dust765.Dust765
                 GameCursor._spellTime = 0;
                 // ## BEGIN - END ## // VISUAL HELPERS
                 if (!GameActions.iscasting)
+                {
                     World.Player.OnCasting.Start((uint)GameActions.LastSpellIndexCursor);
+                }
             }
             // ## BEGIN - END ## // ONCASTINGGUMP
         }

--- a/src/ClassicUO.Client/Dust765/External/OnCastingGump.cs
+++ b/src/ClassicUO.Client/Dust765/External/OnCastingGump.cs
@@ -46,6 +46,11 @@ namespace ClassicUO.Dust765.External
 
         public void Start(uint _spell_id, uint _re = 0)
         {
+            if (_spell_id < 1 || _spell_id > 99)
+            {
+                return;
+            }
+
             _startTime = Time.Ticks;
             uint circle;
 

--- a/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Dust765/UI/Gumps/VersionHistory.cs
@@ -67,6 +67,13 @@ namespace ClassicUO.Dust765.UI.Gumps
             int contentY = 0;
             string[] sections =
             {
+                "/c[yellow]v3.0.11/cd",
+                "",
+                "- Fix: restore SuppressDraw + Thread.Sleep(1) frame limiter (matching upstream CUO)",
+                "- Fix: Texture2D.FromStream moved to main thread in GumpPicExternalUrl",
+                "- Fix: MobileStatusRequestQueue GameActions now dispatched via MainThreadQueue",
+                "- Fix: network backpressure Sleep(0) restored to Sleep(1) to avoid CPU spin",
+                "",
                 "/c[yellow]v3.0.10/cd",
                 "",
                 "- Update for net core 10",

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -221,6 +221,15 @@ namespace ClassicUO.Game.GameObjects
         public bool IsGargoyle =>
             Client.Version >= ClientVersion.CV_7000 && Graphic == 0x029A || Graphic == 0x029B;
 
+        public bool IsInvulnerableMannequin =>
+            NotorietyFlag == NotorietyFlag.Invulnerable
+            && IsHuman
+            && !string.IsNullOrEmpty(Name)
+            && (
+                Name.Contains("mannequin", StringComparison.OrdinalIgnoreCase)
+                || Name.Contains("manequin", StringComparison.OrdinalIgnoreCase)
+            );
+
         public bool IsMounted
         {
             get

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -158,6 +158,15 @@ namespace ClassicUO.Game.Managers
                     continue;
                 }
 
+                if (
+                    ProfileManager.CurrentProfile.HideInvulnerableMannequinsOnInvisibleHouses
+                    && mobile.Serial != World.Player.Serial
+                    && mobile.IsInvulnerableMannequin
+                )
+                {
+                    continue;
+                }
+
                 int current = mobile.Hits;
                 int max = mobile.HitsMax;
 

--- a/src/ClassicUO.Client/Game/Managers/MobileStatusRequestQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MobileStatusRequestQueue.cs
@@ -1,17 +1,14 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
 namespace ClassicUO.Game.Managers
 {
     internal class MobileStatusRequestQueue
     {
-        private ConcurrentQueue<uint> requestedSerials = new ConcurrentQueue<uint>();
+        private readonly ConcurrentQueue<uint> _requestedSerials = new ConcurrentQueue<uint>();
         private static MobileStatusRequestQueue instance;
-        private Task queueProccessor;
+        private Task _queueProcessor;
+
         public static MobileStatusRequestQueue Instance
         {
             get
@@ -20,19 +17,25 @@ namespace ClassicUO.Game.Managers
                 return instance;
             }
         }
-        private MobileStatusRequestQueue(){        }
+
+        private MobileStatusRequestQueue() { }
 
         public void RequestMobileStatus(uint serial)
         {
-            requestedSerials.Enqueue(serial);
-            if (requestedSerials.Count > 0 && (queueProccessor == null || queueProccessor.IsCompleted || !queueProccessor.Status.Equals(TaskStatus.Running)))
+            _requestedSerials.Enqueue(serial);
+
+            if (_queueProcessor == null || _queueProcessor.IsCompleted)
             {
-                queueProccessor = Task.Factory.StartNew(() => {
-                    while (requestedSerials.TryDequeue(out var serial))
+                _queueProcessor = Task.Run(async () =>
+                {
+                    while (_requestedSerials.TryDequeue(out uint s))
                     {
-                        GameActions.RequestMobileStatus(serial);
-                        GameActions.Print($"Processing {serial}");
-                        Task.Delay(1000).Wait();
+                        // GameActions must run on main thread
+                        MainThreadQueue.EnqueueAction(() =>
+                        {
+                            GameActions.RequestMobileStatus(s);
+                        });
+                        await Task.Delay(1000).ConfigureAwait(false);
                     }
                 });
             }

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -166,6 +166,16 @@ namespace ClassicUO.Game.Managers
             if (mobile.Serial == TargetManager.LastTargetInfo.Serial)
                 return true;
 
+            if (mobile.Serial != World.Player.Serial
+                && mobile.IsInvulnerableMannequin
+                && (
+                    ProfileManager.CurrentProfile.HideInvulnerableMannequinNameplates
+                    || ProfileManager.CurrentProfile.HideInvulnerableMannequinsOnInvisibleHouses
+                ))
+            {
+                return false;
+            }
+
             if (mobile.Equals(World.Player) && ActiveOverheadOptions.HasFlag(NameOverheadOptions.ExcludeSelf)
                 && !ActiveOverheadOptions.HasFlag(NameOverheadOptions.Self))
                 return false;

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -1015,6 +1015,17 @@ namespace ClassicUO.Game.Scenes
                 }
                 else if (obj is Mobile mobile)
                 {
+                    Profile pMan = ProfileManager.CurrentProfile;
+                    if (pMan != null
+                        && pMan.HideInvulnerableMannequinsOnInvisibleHouses
+                        && World.Player != null
+                        && mobile.Serial != World.Player.Serial
+                        && mobile.IsInvulnerableMannequin)
+                    {
+                        mobile.ObjectHandlesStatus = ObjectHandlesStatus.NONE;
+                        continue;
+                    }
+
                     UpdateObjectHandles(mobile, useObjectHandles);
 
                     maxObjectZ += Constants.DEFAULT_CHARACTER_HEIGHT;

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPicExternalUrl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPicExternalUrl.cs
@@ -30,6 +30,7 @@
 
 #endregion
 
+using ClassicUO.Game.Managers;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -67,33 +68,30 @@ namespace ClassicUO.Game.UI.Controls
 
         private void getImageTexture()
         {
-            Task.Factory.StartNew(() =>
+            _ = Task.Run(async () =>
             {
                 try
                 {
+                    byte[] pngBytes;
                     using (HttpClient httpClient = new HttpClient())
-                    using (Stream stream = httpClient.GetStreamAsync(ImgUrl).Result)
                     {
-                        using (var image = Image.Load(stream))
-                        {
-                            Console.WriteLine($"Image size {image.Width} x {image.Height}");
-
-                            var memStream = new MemoryStream();
-                            image.Save(memStream, new PngEncoder());
-
-                            using (memStream)
-                            {
-                                var t = Texture2D.FromStream(Client.Game.GraphicsDevice, memStream);
-                                //Color[] buffer = new Color[t.Width * t.Height];
-                                //t.GetData(buffer);
-                                //for (int i = 0; i < buffer.Length; i++)
-                                //    buffer[i] = Color.FromNonPremultiplied(buffer[i].R, buffer[i].G, buffer[i].B, buffer[i].A);
-                                //t.SetData(buffer);
-                                imageTexture = t;
-                            }
-                        }
-
+                        byte[] rawBytes = await httpClient.GetByteArrayAsync(ImgUrl).ConfigureAwait(false);
+                        using var image = Image.Load(rawBytes);
+                        var memStream = new MemoryStream();
+                        image.Save(memStream, new PngEncoder());
+                        pngBytes = memStream.ToArray();
                     }
+
+                    // Texture2D.FromStream must run on the main/render thread
+                    MainThreadQueue.EnqueueAction(() =>
+                    {
+                        try
+                        {
+                            using var ms = new MemoryStream(pngBytes);
+                            imageTexture = Texture2D.FromStream(Client.Game.GraphicsDevice, ms);
+                        }
+                        catch { }
+                    });
                 }
                 catch { }
             });

--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -33,6 +33,7 @@
 using System;
 using System.Collections.Generic;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Game.UI.Gumps.Login;
@@ -155,6 +156,17 @@ namespace ClassicUO.Game.UI.Controls
             AddCheckbox("Enemy (orange)", NameOverheadOptions.Enemy, 0, y);
             AddCheckbox("Murderer (red)", NameOverheadOptions.Murderer, 150, y);
             y += 22;
+            Checkbox hideMannequinNameplate = new Checkbox(0x00D2, 0x00D3, "Nameplate: hide mannequin", 0xFF, 0xFFFF)
+            {
+                IsChecked = ProfileManager.CurrentProfile.HideInvulnerableMannequinNameplates,
+                X = 150,
+                Y = y
+            };
+            hideMannequinNameplate.ValueChanged += (_, _) =>
+            {
+                ProfileManager.CurrentProfile.HideInvulnerableMannequinNameplates = hideMannequinNameplate.IsChecked;
+            };
+            checkBoxScroll.Add(hideMannequinNameplate);
             AddCheckbox("Invulnerable (yellow)", NameOverheadOptions.Invulnerable, 0, y);
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -139,6 +139,7 @@ namespace ClassicUO.Game.UI.Gumps
                          _highlightByParalyzed,
                          _highlightByInvul,
                          _drawRoofs,
+                         _hideInvulnerableMannequinsOnInvisibleHouses,
                          // ## BEGIN - END ## // ART / HUE CHANGES
                          //_treeToStumps,
                          // ## BEGIN - END ## // ART / HUE CHANGES
@@ -152,6 +153,7 @@ namespace ClassicUO.Game.UI.Gumps
                          _chatAfterEnter,
                          _chatAdditionalButtonsCheckbox,
                          _chatShiftEnterCheckbox,
+                         _chatInputAutoLineBreak,
                          _enableCaveBorder;
         private Checkbox _holdShiftForContext, _holdShiftToSplitStack, _reduceFPSWhenInactive, _enableVSync, _sallosEasyGrab, _partyInviteGump, _objectsFading, _textFading, _holdAltToMoveGumps;
         private Combobox _hpComboBox, _healtbarType, _fieldsType, _hpComboBoxShowWhen;
@@ -189,6 +191,7 @@ namespace ClassicUO.Game.UI.Gumps
         // general
         private HSliderBar _sliderFPS, _circleOfTranspRadius;
         private HSliderBar _sliderSpeechDelay;
+        private HSliderBar _chatInputMaxCharsPerLineSlider;
         private HSliderBar _sliderZoom;
         private HSliderBar _soundsVolume, _musicVolume, _loginMusicVolume;
         private HSliderBar _hiddenBodyAlpha;
@@ -1862,6 +1865,18 @@ namespace ClassicUO.Game.UI.Gumps
                 )
             );
 
+            section5.Add
+            (
+                _hideInvulnerableMannequinsOnInvisibleHouses = AddCheckBox
+                (
+                    null,
+                    "Hide mannequin fully",
+                    _currentProfile.HideInvulnerableMannequinsOnInvisibleHouses,
+                    startX,
+                    startY
+                )
+            );
+
             // ## BEGIN - END ## // ART / HUE CHANGES
             /*
             section5.Add
@@ -2944,6 +2959,35 @@ namespace ClassicUO.Game.UI.Gumps
             );
 
             startY += _chatShiftEnterCheckbox.Height + 6;
+            startX = 5;
+
+            _chatInputAutoLineBreak = AddCheckBox
+            (
+                rightArea,
+                ResGumps.ChatInputAutoLineBreak,
+                _currentProfile.ChatInputAutoLineBreak,
+                startX,
+                startY
+            );
+
+            startY += _chatInputAutoLineBreak.Height + 6;
+
+            AddLabel(rightArea, ResGumps.ChatInputMaxCharsPerLine, startX, startY);
+
+            startY += 15;
+
+            _chatInputMaxCharsPerLineSlider = AddHSlider
+            (
+                rightArea,
+                20,
+                120,
+                Math.Clamp(_currentProfile.ChatInputMaxCharsPerLine, 20, 120),
+                startX,
+                startY,
+                180
+            );
+
+            startY += _chatInputMaxCharsPerLineSlider.Height + 6;
             startX = 5;
 
             _hideChatGradient = AddCheckBox
@@ -6392,6 +6436,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _paralyzedColorPickerBox.Hue = 0x014C;
                     _invulnerableColorPickerBox.Hue = 0x0030;
                     _drawRoofs.IsChecked = false;
+                    _hideInvulnerableMannequinsOnInvisibleHouses.IsChecked = false;
                     _enableCaveBorder.IsChecked = false;
                     // ## BEGIN - END ## // ART / HUE CHANGES
                     //_treeToStumps.IsChecked = false;
@@ -6526,6 +6571,8 @@ namespace ClassicUO.Game.UI.Gumps
                     UIManager.SystemChat.IsActive = !_chatAfterEnter.IsChecked;
                     _chatAdditionalButtonsCheckbox.IsChecked = true;
                     _chatShiftEnterCheckbox.IsChecked = true;
+                    _chatInputAutoLineBreak.IsChecked = true;
+                    _chatInputMaxCharsPerLineSlider.Value = 100;
                     _saveJournalCheckBox.IsChecked = false;
                     _hideChatGradient.IsChecked = false;
                     _ignoreGuildMessages.IsChecked = false;
@@ -6845,6 +6892,8 @@ namespace ClassicUO.Game.UI.Gumps
             // ## BEGIN - END ## // ART / HUE CHANGES
 
             _currentProfile.FieldsType = _fieldsType.SelectedIndex;
+            _currentProfile.HideInvulnerableMannequinsOnInvisibleHouses =
+                _hideInvulnerableMannequinsOnInvisibleHouses.IsChecked;
             _currentProfile.HideVegetation = _hideVegetation.IsChecked;
             _currentProfile.NoColorObjectsOutOfRange = _noColorOutOfRangeObjects.IsChecked;
             _currentProfile.UseCircleOfTransparency = _useCircleOfTransparency.IsChecked;
@@ -6973,6 +7022,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             _currentProfile.ActivateChatAdditionalButtons = _chatAdditionalButtonsCheckbox.IsChecked;
             _currentProfile.ActivateChatShiftEnterSupport = _chatShiftEnterCheckbox.IsChecked;
+            _currentProfile.ChatInputAutoLineBreak = _chatInputAutoLineBreak.IsChecked;
+            _currentProfile.ChatInputMaxCharsPerLine = Math.Clamp(_chatInputMaxCharsPerLineSlider.Value, 20, 120);
             _currentProfile.SaveJournalToFile = _saveJournalCheckBox.IsChecked;
 
             // video

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -51,6 +51,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using static SDL3.SDL;
 
 namespace ClassicUO
@@ -69,6 +70,7 @@ namespace ClassicUO
         private uint _totalFrames;
         private uint _lastMainThreadQueueTicks;
         private UltimaBatcher2D _uoSpriteBatch;
+        private bool _suppressedDraw;
         private Texture2D _background;
 
         private static Vector3 bgHueShader = new Vector3(0, 0, 0.3f);
@@ -584,15 +586,24 @@ namespace ClassicUO
                 {
                     _totalElapsed %= frameMs;
                     fullGameTick = true;
+                    _suppressedDraw = false;
                 }
                 else
                 {
                     fullGameTick = false;
+                    _suppressedDraw = true;
+                    SuppressDraw();
+
+                    if (!gameTime.IsRunningSlowly)
+                    {
+                        Thread.Sleep(1);
+                    }
                 }
             }
             else
             {
                 _totalElapsed = 0;
+                _suppressedDraw = false;
             }
 
             FullGameTick = fullGameTick;
@@ -756,7 +767,7 @@ namespace ClassicUO
 
         protected override bool BeginDraw()
         {
-            return base.BeginDraw();
+            return !_suppressedDraw && base.BeginDraw();
         }
 
         private void WindowOnClientSizeChanged(object sender, EventArgs e)

--- a/src/ClassicUO.Client/Network/NetClient.cs
+++ b/src/ClassicUO.Client/Network/NetClient.cs
@@ -136,7 +136,7 @@ namespace ClassicUO.Network
                         else
                         {
                             ProcessSendFromQueue();
-                            Thread.Sleep(0); // cede time slice; watermark faz o throttle real
+                            Thread.Sleep(1); // backpressure: cede CPU para a main thread consumir a fila
                             continue;
                         }
                     }
@@ -144,7 +144,7 @@ namespace ClassicUO.Network
                     {
                         _receiveBackpressure = true;
                         ProcessSendFromQueue();
-                        Thread.Sleep(0); // cede time slice; watermark faz o throttle real
+                        Thread.Sleep(1); // backpressure: cede CPU para a main thread consumir a fila
                         continue;
                     }
 

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -619,6 +619,24 @@ namespace ClassicUO.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Break typed chat into multiple lines.
+        /// </summary>
+        public static string ChatInputAutoLineBreak {
+            get {
+                return ResourceManager.GetString("ChatInputAutoLineBreak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max characters per line (when line break is on):.
+        /// </summary>
+        public static string ChatInputMaxCharsPerLine {
+            get {
+                return ResourceManager.GetString("ChatInputMaxCharsPerLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You are about to choose your name for the Ultima Online chat system. This name will be PERMANENT and unique on this shard. It will apply to all characters using this account. Do not use your Ultima Online account name for this name as the name you choose will be public. Enter your chat name here:.
         /// </summary>
         public static string ChooseName {

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -586,6 +586,12 @@ delete it?</value>
   <data name="ChatMessageColor" xml:space="preserve">
     <value>Chat Message Color</value>
   </data>
+  <data name="ChatInputAutoLineBreak" xml:space="preserve">
+    <value>Break typed chat into multiple lines</value>
+  </data>
+  <data name="ChatInputMaxCharsPerLine" xml:space="preserve">
+    <value>Max characters per line (when line break is on):</value>
+  </data>
   <data name="QueryAttack" xml:space="preserve">
     <value>Query before attack</value>
   </data>


### PR DESCRIPTION
- GameController: restore SuppressDraw + BeginDraw guard + Thread.Sleep(1) matching upstream ClassicUO frame limiter (fixes GPU flood + CPU busy-loop)
- GumpPicExternalUrl: move Texture2D.FromStream to main thread via MainThreadQueue (was causing GraphicsDevice race condition from background thread)
- MobileStatusRequestQueue: dispatch GameActions via MainThreadQueue (GameActions is not thread-safe, was called from Task background thread)
- NetClient: restore Thread.Sleep(1) on backpressure (was Sleep(0) busy-loop that competed with main thread for CPU)
- Bump version 3.0.10 -> 3.0.11